### PR TITLE
isolate pgx batching logic to specific file and improve debugging

### DIFF
--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -102,9 +102,9 @@ func (q *QueryBatch) persistBatch() error {
 	if qerr != nil {
 		log.WithFields(log.Fields{
 			"error": qerr.Error(),
-			"query": q.persistables[cnt+1].query,
-			"values": q.persistables[cnt+1].values,
-		}).Errorf("unable to persist query [%d]", cnt+1)
+			"query": q.persistables[cnt-1].query,
+			"values": q.persistables[cnt-1].values,
+		}).Errorf("unable to persist query [%d]", cnt-1)
 		return errors.Wrap(qerr, "error persisting batch")
 	}
 	return nil

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -1,0 +1,136 @@
+package db
+
+import (
+"context"
+	"time"
+
+	pgx "github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	QueryTimeout = 5 * time.Minute
+	MaxRetries   = 1
+
+	ErrorNoConnFree = "no connection adquirable"
+	noQueryError  string = "no error"
+	noQueryResult string = "no result"
+)
+
+type QueryBatch struct {
+	ctx     context.Context
+	pgxPool *pgxpool.Pool
+	batch   *pgx.Batch
+	size    int
+	persistables []Persistable
+}
+
+func NewQueryBatch(ctx context.Context, pgxPool *pgxpool.Pool, batchSize int) *QueryBatch {
+	return &QueryBatch{
+		ctx:     ctx,
+		pgxPool: pgxPool,
+		batch:   &pgx.Batch{},
+		size:    batchSize,
+		persistables: make([]Persistable, 0),
+	}
+}
+
+func (q *QueryBatch) IsReadyToPersist() bool {
+	return q.batch.Len() >= q.size
+}
+
+func (q *QueryBatch) AddQuery(persis Persistable) {
+	q.batch.Queue(persis.query, persis.values...)
+	q.persistables = append(q.persistables, persis)
+}
+
+func (q *QueryBatch) Len() int {
+	return q.batch.Len()
+}
+
+func (q *QueryBatch) PersistBatch() error {
+	logEntry := log.WithFields(log.Fields{
+		"mod": "batch-persister",
+	})
+	wlog.Debugf("persisting batch of queries with len(%d)", q.Len())
+	var err error
+persistRetryLoop:
+	for i := 0; i < MaxRetries; i++ {
+		t := time.Now()
+		err = q.persistBatch()
+		duration := time.Since(t)
+		switch err {
+		case nil:
+			logEntry.Tracef("persisted %d queries in %s seconds", q.Len(), duration)
+			break persistRetryLoop
+		default:
+			logEntry.Tracef("attempt numb %d failed %s", i+1, err.Error())
+		}
+	}
+	q.cleanBatch()
+	return errors.Wrap(err, "unable to persist batch query")
+}
+
+func (q *QueryBatch) persistBatch() error {
+	logEntry := log.WithFields(log.Fields{
+		"mod": "batch-persister",
+	})
+
+	if q.Len() == 0 {
+		logEntry.Trace("skipping batch-query, no queries to persist")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(q.ctx, QueryTimeout)
+	defer cancel()
+
+	batchResults := q.pgxPool.SendBatch(ctx, q.batch)
+	defer batchResults.Close()
+
+	var qerr error
+	var rows pgx.Rows
+	nextQuery := true
+	cnt := 0
+	for nextQuery {
+		rows, qerr = batchResults.Query()
+		nextQuery = rows.Next() // it closes all the rows if all the rows are readed
+		cnt++
+	}
+	// check if there was any error
+	if qerr != nil {
+		log.WithFields(log.Fields{
+			"error": qerr.Error(),
+			"query": q.persistables[cnt+1].query,
+			"values": q.persistables[cnt+1].values,
+		}).Errorf("unable to persist query [%d]", cnt+1)
+		return errors.Wrap(qerr, "error persisting batch")
+	}
+	return nil
+}
+
+func (q *QueryBatch) cleanBatch() {
+	q.batch = &pgx.Batch{}
+	q.persistables = make([]Persistable, 0)
+}
+
+
+// persistable is the main structure fed to the batcher
+// allows to link batching errors with the query and values 
+// that generated it
+type Persistable struct {
+	query string
+	values []interface{}
+}
+
+func NewPersistable() Persistable {
+	return Persistable{
+		values: make([]interface{}, 0),
+	}
+}
+
+func (p *Persistable) isEmpty() bool {
+	return p.query == ""
+}
+


### PR DESCRIPTION
# Description
As the project's complexity keeps increasing, and more features keep getting added, the logic of the PSQL client misses some updates to know which query is failing under which parameters. So, this PR is actually trying to fix it.

The PR focuses on isolating the batching logic of the PSQL client into a single struct -> `QueryBatch` with dedicated methods. This means we can keep track of the queries and values that will be persisted, which ultimately helps us debug which query failed under which values.

# Update
The update works fine (check image bellow)
![image](https://github.com/cortze/goteth/assets/45786396/1b0aaaa5-d123-4fb2-928c-75eac11fb216)
 
and allows to track any incomplete query that wants to be persisted:
```
ERRO[2023-06-01T11:02:35+02:00] unable to persist query [0]                   error="ERROR: column \"on_pu
rpose_error\" of relation \"t_epoch_metrics_summary\" does not exist (SQLSTATE 42703)" query="\n\tINSERT I
NTO t_epoch_metrics_summary (\n\t\tf_epoch, \n\t\ton_purpose_error, \n\t\tf_num_att, \n\t\tf_num_att_vals,
 \n\t\tf_num_vals, \n\t\tf_total_balance_eth,\n\t\tf_att_effective_balance_eth,  \n\t\tf_total_effective_b
alance_eth, \n\t\tf_missing_source, \n\t\tf_missing_target, \n\t\tf_missing_head)\n\t\tVALUES ($1, $2, $3,
 $4, $5, $6, $7, $8, $9, $10, $11)\n\t\tON CONFLICT ON CONSTRAINT PK_Epoch\n\t\tDO \n\t\t\tUPDATE SET \n\t
\t\t\tf_num_att = excluded.f_num_att, \n\t\t\t\tf_num_att_vals = excluded.f_num_att_vals,\n\t\t\t\tf_num_v
als = excluded.f_num_vals,\n\t\t\t\tf_total_balance_eth = excluded.f_total_balance_eth,\n\t\t\t\tf_att_eff
ective_balance_eth = excluded.f_att_effective_balance_eth,\n\t\t\t\tf_total_effective_balance_eth = exclud
ed.f_total_effective_balance_eth,\n\t\t\t\tf_missing_source = excluded.f_missing_source,\n\t\t\t\tf_missin
g_target = excluded.f_missing_target,\n\t\t\t\tf_missing_head = excluded.f_missing_head;\n\t" values="[106
250 3400031 0 316126 350969 1.1647489e+07 1.0115077e+07 1.1219689e+07 36670 34846 58724]"
ERRO[2023-06-01T11:02:35+02:00] Error processing batch%!(EXTRA string=unable to persist batch query: error
 persisting batch: ERROR: column "on_purpose_error" of relation "t_epoch_metrics_summary" does not exist (
SQLSTATE 42703))  DBWriter=0 module=postgres-db
```  

