### PR TITLE
Refactor API requests into clientapi package

### DIFF
--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/attestantio/go-eth2-client/spec/altair"
-	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/db"
@@ -14,7 +12,6 @@ import (
 
 	"github.com/cortze/eth-cl-state-analyzer/pkg/events"
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/go-bitfield"
 )
 
 type BlockAnalyzer struct {
@@ -153,42 +150,4 @@ type BlockTask struct {
 type TransactionTask struct {
 	Slot         uint64
 	Transactions []*spec.AgnosticTransaction
-}
-
-func (s BlockAnalyzer) CreateMissingBlock(slot phase0.Slot) spec.AgnosticBlock {
-	duties, err := s.cli.Api.ProposerDuties(s.ctx, phase0.Epoch(slot/32), []phase0.ValidatorIndex{})
-	proposerValIdx := phase0.ValidatorIndex(0)
-	if err != nil {
-		log.Errorf("could not request proposer duty: %s", err)
-	} else {
-		for _, duty := range duties {
-			if duty.Slot == phase0.Slot(slot) {
-				proposerValIdx = duty.ValidatorIndex
-			}
-		}
-	}
-
-	return spec.AgnosticBlock{
-		Slot:              slot,
-		ProposerIndex:     proposerValIdx,
-		Graffiti:          [32]byte{},
-		Proposed:          false,
-		Attestations:      make([]*phase0.Attestation, 0),
-		Deposits:          make([]*phase0.Deposit, 0),
-		ProposerSlashings: make([]*phase0.ProposerSlashing, 0),
-		AttesterSlashings: make([]*phase0.AttesterSlashing, 0),
-		VoluntaryExits:    make([]*phase0.SignedVoluntaryExit, 0),
-		SyncAggregate: &altair.SyncAggregate{
-			SyncCommitteeBits:      bitfield.NewBitvector512(),
-			SyncCommitteeSignature: phase0.BLSSignature{}},
-		ExecutionPayload: spec.AgnosticExecutionPayload{
-			FeeRecipient:  bellatrix.ExecutionAddress{},
-			GasLimit:      0,
-			GasUsed:       0,
-			Timestamp:     0,
-			BaseFeePerGas: [32]byte{},
-			BlockHash:     phase0.Hash32{},
-			Transactions:  make([]bellatrix.Transaction, 0),
-		},
-	}
 }

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -3,8 +3,6 @@ package clientapi
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/http"
@@ -73,10 +71,4 @@ func WithELEndpoint(url string) APIClientOption {
 		s.ELApi = client
 		return nil
 	}
-}
-
-// GetReceipt retrieves receipt for the given transaction hash
-func (client APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
-	receipt, err := client.ELApi.TransactionReceipt(client.ctx, txHash)
-	return receipt, err
 }

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -1,0 +1,69 @@
+package clientapi
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+	"github.com/prysmaticlabs/go-bitfield"
+)
+
+func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, bool, error) {
+	newBlock, err := s.Api.SignedBeaconBlock(s.ctx, fmt.Sprintf("%d", slot))
+	if newBlock == nil {
+		log.Warnf("the beacon block at slot %d does not exist, missing block", slot)
+		return s.CreateMissingBlock(slot), false, nil
+	}
+	if err != nil {
+		// close the channel (to tell other routines to stop processing and end)
+		return spec.AgnosticBlock{}, false, fmt.Errorf("unable to retrieve Beacon Block at slot %d: %s", slot, err.Error())
+	}
+
+	customBlock, err := spec.GetCustomBlock(*newBlock)
+
+	if err != nil {
+		// close the channel (to tell other routines to stop processing and end)
+		return spec.AgnosticBlock{}, false, fmt.Errorf("unable to parse Beacon Block at slot %d: %s", slot, err.Error())
+	}
+	return customBlock, true, nil
+}
+
+func (s APIClient) CreateMissingBlock(slot phase0.Slot) spec.AgnosticBlock {
+	duties, err := s.Api.ProposerDuties(s.ctx, phase0.Epoch(slot/32), []phase0.ValidatorIndex{})
+	proposerValIdx := phase0.ValidatorIndex(0)
+	if err != nil {
+		log.Errorf("could not request proposer duty: %s", err)
+	} else {
+		for _, duty := range duties {
+			if duty.Slot == phase0.Slot(slot) {
+				proposerValIdx = duty.ValidatorIndex
+			}
+		}
+	}
+
+	return spec.AgnosticBlock{
+		Slot:              slot,
+		ProposerIndex:     proposerValIdx,
+		Graffiti:          [32]byte{},
+		Proposed:          false,
+		Attestations:      make([]*phase0.Attestation, 0),
+		Deposits:          make([]*phase0.Deposit, 0),
+		ProposerSlashings: make([]*phase0.ProposerSlashing, 0),
+		AttesterSlashings: make([]*phase0.AttesterSlashing, 0),
+		VoluntaryExits:    make([]*phase0.SignedVoluntaryExit, 0),
+		SyncAggregate: &altair.SyncAggregate{
+			SyncCommitteeBits:      bitfield.NewBitvector512(),
+			SyncCommitteeSignature: phase0.BLSSignature{}},
+		ExecutionPayload: spec.AgnosticExecutionPayload{
+			FeeRecipient:  bellatrix.ExecutionAddress{},
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			BaseFeePerGas: [32]byte{},
+			BlockHash:     phase0.Hash32{},
+			Transactions:  make([]bellatrix.Transaction, 0),
+		},
+	}
+}

--- a/pkg/clientapi/duties.go
+++ b/pkg/clientapi/duties.go
@@ -1,0 +1,47 @@
+package clientapi
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+func (s APIClient) NewEpochData(slot phase0.Slot) spec.EpochDuties {
+
+	epochCommittees, err := s.Api.BeaconCommittees(context.Background(), strconv.Itoa(int(slot)))
+
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+
+	validatorsAttSlot := make(map[phase0.ValidatorIndex]phase0.Slot) // each validator, when it had to attest
+	validatorsPerSlot := make(map[phase0.Slot][]phase0.ValidatorIndex)
+
+	for _, committee := range epochCommittees {
+		for _, valID := range committee.Validators {
+			validatorsAttSlot[valID] = committee.Slot
+
+			if val, ok := validatorsPerSlot[committee.Slot]; ok {
+				// the slot exists in the map
+				validatorsPerSlot[committee.Slot] = append(val, valID)
+			} else {
+				// the slot does not exist, create
+				validatorsPerSlot[committee.Slot] = []phase0.ValidatorIndex{valID}
+			}
+		}
+	}
+
+	proposerDuties, err := s.Api.ProposerDuties(context.Background(), phase0.Epoch(slot/spec.SlotsPerEpoch), nil)
+
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+
+	return spec.EpochDuties{
+		ProposerDuties:   proposerDuties,
+		BeaconCommittees: epochCommittees,
+		ValidatorAttSlot: validatorsAttSlot,
+	}
+}

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -1,0 +1,28 @@
+package clientapi
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	local_spec "github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+func (s APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticState, error) {
+	newState, err := s.Api.BeaconState(s.ctx, fmt.Sprintf("%d", slot))
+	if newState == nil {
+		return nil, fmt.Errorf("unable to retrieve Finalized Beacon State from the beacon node, closing requester routine. nil State")
+	}
+	if err != nil {
+		// close the channel (to tell other routines to stop processing and end)
+		return nil, fmt.Errorf("unable to retrieve Finalized Beacon State from the beacon node, closing requester routine. %s", err.Error())
+
+	}
+
+	resultState, err := local_spec.GetCustomState(*newState, s.NewEpochData(slot))
+	if err != nil {
+		// close the channel (to tell other routines to stop processing and end)
+		return nil, fmt.Errorf("unable to open beacon state, closing requester routine. %s", err.Error())
+	}
+
+	return &resultState, nil
+}

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -1,0 +1,77 @@
+package clientapi
+
+import (
+	"encoding/hex"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// GetReceipt retrieves receipt for the given transaction hash
+func (client APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
+	receipt, err := client.ELApi.TransactionReceipt(client.ctx, txHash)
+	return receipt, err
+}
+
+// convert transactions from byte sequences to Transaction object
+func (s APIClient) RequestTransactionDetails(block spec.AgnosticBlock) ([]*spec.AgnosticTransaction, error) {
+	processedTransactions := make([]*spec.AgnosticTransaction, 0)
+	if s.ELApi == nil {
+		log.Warn("EL endpoint not provided. The gas price read from the CL may not be the effective gas price.")
+	}
+	for idx := 0; idx < len(block.ExecutionPayload.Transactions); idx++ {
+		var parsedTx = &types.Transaction{}
+		if err := parsedTx.UnmarshalBinary(block.ExecutionPayload.Transactions[idx]); err != nil {
+			log.Warnf("unable to unmarshal transaction: %s", err)
+			return processedTransactions, err
+		}
+		from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), parsedTx)
+		if err != nil {
+			log.Warnf("unable to retrieve sender address from transaction: %s", err)
+			return processedTransactions, err
+		}
+
+		gasUsed := parsedTx.Gas()
+		gasPrice := parsedTx.GasPrice().Uint64()
+		contractAddress := *&common.Address{}
+
+		if s.ELApi != nil {
+			receipt, err := s.GetReceipt(parsedTx.Hash())
+
+			if err != nil {
+				log.Warnf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
+			} else {
+				gasUsed = receipt.GasUsed
+				gasPrice = receipt.EffectiveGasPrice.Uint64()
+				contractAddress = receipt.ContractAddress
+			}
+
+		}
+
+		processedTransaction := &spec.AgnosticTransaction{
+			TxType:          parsedTx.Type(),
+			ChainId:         uint8(parsedTx.ChainId().Uint64()),
+			Data:            hex.EncodeToString(parsedTx.Data()),
+			Gas:             phase0.Gwei(gasUsed),
+			GasPrice:        phase0.Gwei(gasPrice),
+			GasTipCap:       phase0.Gwei(parsedTx.GasTipCap().Uint64()),
+			GasFeeCap:       phase0.Gwei(parsedTx.GasFeeCap().Uint64()),
+			Value:           phase0.Gwei(parsedTx.Value().Uint64()),
+			Nonce:           parsedTx.Nonce(),
+			To:              parsedTx.To(),
+			From:            from,
+			Hash:            phase0.Hash32(parsedTx.Hash()),
+			Size:            parsedTx.Size(),
+			Slot:            block.Slot,
+			BlockNumber:     block.ExecutionPayload.BlockNumber,
+			Timestamp:       block.ExecutionPayload.Timestamp,
+			ContractAddress: contractAddress,
+		}
+
+		processedTransactions = append(processedTransactions, processedTransaction)
+
+	}
+	return processedTransactions, nil
+}

--- a/pkg/db/migrations/000006_create_trasactions_table.up.sql
+++ b/pkg/db/migrations/000006_create_trasactions_table.up.sql
@@ -10,7 +10,6 @@ CREATE TABLE IF NOT EXISTS t_transactions(
     f_value NUMERIC,
     f_nonce BIGINT,
     f_to TEXT DEFAULT '',
-    f_from TEXT DEFAULT '',
     f_hash TEXT PRIMARY KEY,
     f_size BIGINT,
 	f_slot INT,

--- a/pkg/spec/transactions.go
+++ b/pkg/spec/transactions.go
@@ -1,11 +1,8 @@
 package spec
 
 import (
-	"encoding/hex"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // A wrapper for blockchain transaction with basic information retrieved from the Ethereum blockchain
@@ -31,65 +28,4 @@ type AgnosticTransaction struct {
 
 func (txs AgnosticTransaction) Type() ModelType {
 	return TransactionsModel
-}
-
-// convert transactions from byte sequences to Transaction object
-func RequestTransactionDetails(block AgnosticBlock, client *clientapi.APIClient) ([]*AgnosticTransaction, error) {
-	processedTransactions := make([]*AgnosticTransaction, 0)
-	if client.ELApi == nil {
-		log.Warn("EL endpoint not provided. The gas price read from the CL may not be the effective gas price.")
-	}
-	for idx := 0; idx < len(block.ExecutionPayload.Transactions); idx++ {
-		var parsedTx = &types.Transaction{}
-		if err := parsedTx.UnmarshalBinary(block.ExecutionPayload.Transactions[idx]); err != nil {
-			log.Warnf("unable to unmarshal transaction: %s", err)
-			return processedTransactions, err
-		}
-		from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), parsedTx)
-		if err != nil {
-			log.Warnf("unable to retrieve sender address from transaction: %s", err)
-			return processedTransactions, err
-		}
-
-		gasUsed := parsedTx.Gas()
-		gasPrice := parsedTx.GasPrice().Uint64()
-		contractAddress := *&common.Address{}
-
-		if client.ELApi != nil {
-			receipt, err := client.GetReceipt(parsedTx.Hash())
-
-			if err != nil {
-				log.Warnf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
-			} else {
-				gasUsed = receipt.GasUsed
-				gasPrice = receipt.EffectiveGasPrice.Uint64()
-				contractAddress = receipt.ContractAddress
-			}
-
-		}
-
-		processedTransaction := &AgnosticTransaction{
-			TxType:          parsedTx.Type(),
-			ChainId:         uint8(parsedTx.ChainId().Uint64()),
-			Data:            hex.EncodeToString(parsedTx.Data()),
-			Gas:             phase0.Gwei(gasUsed),
-			GasPrice:        phase0.Gwei(gasPrice),
-			GasTipCap:       phase0.Gwei(parsedTx.GasTipCap().Uint64()),
-			GasFeeCap:       phase0.Gwei(parsedTx.GasFeeCap().Uint64()),
-			Value:           phase0.Gwei(parsedTx.Value().Uint64()),
-			Nonce:           parsedTx.Nonce(),
-			To:              parsedTx.To(),
-			From:            from,
-			Hash:            phase0.Hash32(parsedTx.Hash()),
-			Size:            parsedTx.Size(),
-			Slot:            block.Slot,
-			BlockNumber:     block.ExecutionPayload.BlockNumber,
-			Timestamp:       block.ExecutionPayload.Timestamp,
-			ContractAddress: contractAddress,
-		}
-
-		processedTransactions = append(processedTransactions, processedTransaction)
-
-	}
-	return processedTransactions, nil
 }


### PR DESCRIPTION
# Motivation
As we have recently added the requests to gather execution layer data, the tool is increasing the number of objects that it retrieves from the beacon and execution node.
Therefore, we feel the need to refactor and organize how the requests are done.

# Description
The main problem right now is that the `spec` package is using the API package, which should not happen. The `spec` package merely contains the data structures of the specification adapted to our project. Therefore, our intention is to isolate all queries only in the `clientapi` package, which should return the objects in the data structures we have defined.

# TODOs

- [x] Move requests to clientapi folder
- [x] Remove API dependency in the spec package


