### PR TITLE
Fetch block size from el client

### DIFF
--- a/pkg/analyzer/metrics_test.go
+++ b/pkg/analyzer/metrics_test.go
@@ -574,3 +574,27 @@ func TestTransactionNotEffectiveGasPriceWhenELNotProvided(t *testing.T) {
 	assert.Equal(t, transactions[10].Hash.String(), "0x737319e9325ddbb754908d0874dac9f95fbb6c1f49cf5f88c389b98ebb61d36c")
 	assert.NotEqual(t, transactions[10].GasPrice, phase0.Gwei(94245102754))
 }
+
+func TestBlockSizeIsSetWhenELIsProvided(t *testing.T) {
+	blockAnalyzer, err := BuildBlockAnalyzerWithEL()
+
+	if err != nil {
+		fmt.Errorf("could not build analyzer: %s", err)
+		return
+	}
+
+	block, _, err := blockAnalyzer.cli.RequestBeaconBlock(5610381) //block number 16442285
+	assert.Equal(t, block.Size, uint64(69157))
+}
+
+func TestBlockSizeNotSetWhenELNotProvided(t *testing.T) {
+	blockAnalyzer, err := BuildBlockAnalyzer()
+
+	if err != nil {
+		fmt.Errorf("could not build analyzer: %s", err)
+		return
+	}
+
+	block, _, err := blockAnalyzer.cli.RequestBeaconBlock(5610381) //block number 16442285
+	assert.Equal(t, block.Size, uint64(0))
+}

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -2,6 +2,8 @@ package clientapi
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
@@ -27,6 +29,16 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, boo
 		// close the channel (to tell other routines to stop processing and end)
 		return spec.AgnosticBlock{}, false, fmt.Errorf("unable to parse Beacon Block at slot %d: %s", slot, err.Error())
 	}
+
+	// fill in block size on custom block using RequestBlockByHash
+	block, err := s.RequestBlockByHash(common.Hash(customBlock.ExecutionPayload.BlockHash))
+	if err != nil {
+		log.Error(err)
+	}
+	if block != nil {
+		customBlock.Size = block.Size()
+	}
+
 	return customBlock, true, nil
 }
 
@@ -66,4 +78,13 @@ func (s APIClient) CreateMissingBlock(slot phase0.Slot) spec.AgnosticBlock {
 			Transactions:  make([]bellatrix.Transaction, 0),
 		},
 	}
+}
+
+// RequestBlockByHash retrieves block from the execution client for the given hash
+func (s APIClient) RequestBlockByHash(hash common.Hash) (*types.Block, error) {
+	block, err := s.ELApi.BlockByHash(s.ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve block by hash %s: %s", hash.String(), err.Error())
+	}
+	return block, nil
 }

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -82,6 +82,9 @@ func (s APIClient) CreateMissingBlock(slot phase0.Slot) spec.AgnosticBlock {
 
 // RequestBlockByHash retrieves block from the execution client for the given hash
 func (s APIClient) RequestBlockByHash(hash common.Hash) (*types.Block, error) {
+	if s.ELApi == nil {
+		return nil, fmt.Errorf("execution layer client is not initialized")
+	}
 	block, err := s.ELApi.BlockByHash(s.ctx, hash)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve block by hash %s: %s", hash.String(), err.Error())

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -36,8 +36,9 @@ var (
 		f_el_base_fee_per_gas,
 		f_el_block_hash,
 		f_el_transactions,
-		f_el_block_number)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		f_el_block_number,
+		f_size)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 		ON CONFLICT ON CONSTRAINT PK_Slot
 		DO NOTHING;
 	`
@@ -70,6 +71,7 @@ func insertBlock(inputBlock spec.AgnosticBlock) (string, []interface{}) {
 	resultArgs = append(resultArgs, inputBlock.ExecutionPayload.BlockHash.String())
 	resultArgs = append(resultArgs, len(inputBlock.ExecutionPayload.Transactions))
 	resultArgs = append(resultArgs, inputBlock.ExecutionPayload.BlockNumber)
+	resultArgs = append(resultArgs, inputBlock.Size)
 
 	return UpsertBlock, resultArgs
 }

--- a/pkg/db/migrations/000012_alter_block_metrics_add_size.down.sql
+++ b/pkg/db/migrations/000012_alter_block_metrics_add_size.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_block_metrics DROP COLUMN IF EXISTS f_size;

--- a/pkg/db/migrations/000012_alter_block_metrics_add_size.up.sql
+++ b/pkg/db/migrations/000012_alter_block_metrics_add_size.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_block_metrics ADD COLUMN f_size numeric DEFAULT 0;

--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -23,6 +23,7 @@ type AgnosticBlock struct {
 	VoluntaryExits    []*phase0.SignedVoluntaryExit
 	SyncAggregate     *altair.SyncAggregate
 	ExecutionPayload  AgnosticExecutionPayload
+	Size              uint64
 }
 
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs


### PR DESCRIPTION
# Motivation
The motivation behind this pull request is to address the issue where the size of each block is not included in the agnostic block. Currently, the size of a block is required, but it is not provided in the existing implementation. To obtain the size, a query to the execution node is necessary to fetch the block and retrieve its size. This pull request aims to enhance the functionality by adding the size property to the block and retrieving the block size from the execution client.

# Description
This pull request introduces several changes to the codebase. The key modifications are as follows:

1. The "size" property is added to the block structure, allowing the storage of the block size information.
2. The block size is obtained from the execution client by querying the respective execution node.
3. The block size is persisted in the database, and migrations are included to add the "f_size" field.
4. A check is implemented to ensure that the ELApi (Execution Layer API) is properly initialized before requesting a block by hash.
5. Tests are added to cover the functionality of retrieving a block by hash and verifying the correctness of the block size.

Method used:

1. [BlockByHash](https://pkg.go.dev/github.com/ethereum/go-ethereum/ethclient#Client.BlockByHash)

# TODOs
- [x] Add size property to block and retrieve block size from execution client
- [x] Persist block size and write migrations for the field "f_size"
- [x] Check that ELApi is initialized before requesting for a block by hash
- [x] Add tests for retrieving a block by hash
