### PR TITLE
Track and verify finalized checkpoints

### DIFF
--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -92,8 +92,8 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 					return
 				}
 			}
-		// case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
-		// 	// slot must be the last slot previous to the finalized epoch
+		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+			s.dbClient.Persist(db.ChepointTypeFromCheckpoint(newFinalCheckpoint))
 
 		case newReorg := <-s.eventsObj.ReorgChan:
 			s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -1,11 +1,11 @@
 package analyzer
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/utils"
 )
 
@@ -13,6 +13,7 @@ import (
 func (s *BlockAnalyzer) runDownloadBlocks(wgDownload *sync.WaitGroup) {
 	defer wgDownload.Done()
 	log.Info("Launching Beacon Block Requester")
+	rootHistory := NewSlotHistory()
 
 loop:
 	// loop over the list of slots that we need to analyze
@@ -30,11 +31,7 @@ loop:
 			}
 
 			log.Infof("requesting Beacon Block from endpoint: slot %d", slot)
-			err := s.DownloadNewBlock(phase0.Slot(slot))
-
-			if err != nil {
-				log.Errorf("error downloading block at slot %d: %s", slot, err)
-			}
+			s.DownloadNewBlock(&rootHistory, phase0.Slot(slot))
 
 		}
 
@@ -47,47 +44,34 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 	defer wgDownload.Done()
 	log.Info("Launching Beacon Block Finalized Requester")
 
+	rootHistory := NewSlotHistory()
 	// ------ fill from last epoch in database to current head -------
 
+	// obtain current head
+	headSlot, _ := s.cli.GetFinalizedEndSlotStateRoot()
+
 	// obtain last epoch in database
-	lastRequestSlot, err := s.dbClient.ObtainLastSlot()
+	nextSlotDownload, err := s.dbClient.ObtainLastSlot()
 	if err != nil {
 		log.Errorf("could not obtain last slot in database: %s", err)
 	}
-
-	// obtain current head
-	headSlot := phase0.Slot(0)
-	header, err := s.cli.Api.BeaconBlockHeader(s.ctx, "head")
-	if err != nil {
-		log.Errorf("could not obtain current head to fill historical")
-	} else {
-		headSlot = header.Header.Message.Slot
+	if nextSlotDownload == 0 {
+		nextSlotDownload = headSlot
 	}
 
-	// it means we could obtain both
-	if lastRequestSlot > 0 && headSlot > 0 {
-
-		for lastRequestSlot < (headSlot - 1) {
-			lastRequestSlot = lastRequestSlot + 1
-
-			log.Infof("filling missing blocks: %d", lastRequestSlot)
-
-			err := s.DownloadNewBlock(phase0.Slot(lastRequestSlot))
-
-			if err != nil {
-				log.Errorf("error downloading block at slot %d: %s", lastRequestSlot, err)
-			}
-
-			if s.stop {
-				log.Info("sudden shutdown detected, block downloader routine")
-				return
-			}
+	for nextSlotDownload < headSlot {
+		log.Infof("filling missing blocks: %d", nextSlotDownload)
+		s.DownloadNewBlock(&rootHistory, phase0.Slot(nextSlotDownload))
+		nextSlotDownload = nextSlotDownload + 1
+		if s.stop {
+			log.Info("sudden shutdown detected, block downloader routine")
+			return
 		}
-
 	}
 
 	// -----------------------------------------------------------------------------------
 	s.eventsObj.SubscribeToHeadEvents()
+	s.eventsObj.SubscribeToFinalizedCheckpointEvents()
 	ticker := time.NewTicker(utils.RoutineFlushTimeout)
 	// loop over the list of slots that we need to analyze
 
@@ -98,21 +82,23 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 			// make the block query
 			log.Infof("received new head signal: %d", headSlot)
 
-			if lastRequestSlot >= headSlot {
-				log.Infof("No new head block yet")
-				continue
-			}
-			if lastRequestSlot == 0 {
-				lastRequestSlot = headSlot
-			}
-			for lastRequestSlot < headSlot {
-				lastRequestSlot = lastRequestSlot + 1
-				err := s.DownloadNewBlock(lastRequestSlot)
-
-				if err != nil {
-					log.Errorf("error downloading block at slot %d: %s", lastRequestSlot, err)
+			for nextSlotDownload < headSlot {
+				log.Infof("downloading block: %d", nextSlotDownload)
+				s.DownloadNewBlock(&rootHistory, phase0.Slot(nextSlotDownload))
+				nextSlotDownload = nextSlotDownload + 1
+				if s.stop {
+					log.Info("sudden shutdown detected, block downloader routine")
+					return
 				}
+			}
+		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+			// slot must be the last slot previous to the finalized epoch
+			finalizedSlot := phase0.Slot(newFinalCheckpoint.Epoch * spec.SlotsPerEpoch)
+			root := s.cli.RequestStateRoot(finalizedSlot)
+			ok, slot := rootHistory.CheckFinalized(finalizedSlot, root)
 
+			if !ok {
+				nextSlotDownload = slot
 			}
 
 		case <-s.ctx.Done():
@@ -129,13 +115,14 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 	}
 }
 
-func (s BlockAnalyzer) DownloadNewBlock(slot phase0.Slot) error {
+func (s BlockAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Slot) {
 
 	ticker := time.NewTicker(minBlockReqTime)
 	newBlock, proposed, err := s.cli.RequestBeaconBlock(slot)
 	if err != nil {
-		return fmt.Errorf("block error at slot %d: %s", slot, err)
+		log.Panicf("block error at slot %d: %s", slot, err)
 	}
+	history.AddRoot(slot, newBlock.StateRoot)
 
 	// send task to be processed
 	blockTask := &BlockTask{
@@ -161,5 +148,4 @@ func (s BlockAnalyzer) DownloadNewBlock(slot phase0.Slot) error {
 
 	<-ticker.C
 	// check if the min Request time has been completed (to avoid spaming the API)
-	return nil
 }

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/db"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/utils"
 )
 
@@ -72,6 +72,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 	// -----------------------------------------------------------------------------------
 	s.eventsObj.SubscribeToHeadEvents()
 	s.eventsObj.SubscribeToFinalizedCheckpointEvents()
+	s.eventsObj.SubscribeToReorgsEvents()
 	ticker := time.NewTicker(utils.RoutineFlushTimeout)
 	// loop over the list of slots that we need to analyze
 
@@ -82,7 +83,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 			// make the block query
 			log.Infof("received new head signal: %d", headSlot)
 
-			for nextSlotDownload < headSlot {
+			for nextSlotDownload <= headSlot {
 				log.Infof("downloading block: %d", nextSlotDownload)
 				s.DownloadNewBlock(&rootHistory, phase0.Slot(nextSlotDownload))
 				nextSlotDownload = nextSlotDownload + 1
@@ -91,15 +92,15 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 					return
 				}
 			}
-		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
-			// slot must be the last slot previous to the finalized epoch
-			finalizedSlot := phase0.Slot(newFinalCheckpoint.Epoch * spec.SlotsPerEpoch)
-			root := s.cli.RequestStateRoot(finalizedSlot)
-			ok, slot := rootHistory.CheckFinalized(finalizedSlot, root)
+		// case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+		// 	// slot must be the last slot previous to the finalized epoch
 
-			if !ok {
-				nextSlotDownload = slot
-			}
+		case newReorg := <-s.eventsObj.ReorgChan:
+			s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))
+			log.Infof("rewinding to %d", newReorg.Slot-phase0.Slot(newReorg.Depth))
+
+			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth) + 1
+			s.ReorgRewind(nextSlotDownload)
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing block requester routine")
@@ -148,4 +149,13 @@ func (s BlockAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Sl
 
 	<-ticker.C
 	// check if the min Request time has been completed (to avoid spaming the API)
+}
+
+func (s *BlockAnalyzer) ReorgRewind(slot phase0.Slot) {
+
+	log.Infof("deleting block data from %d (included) onwards", slot)
+	s.dbClient.Persist(db.BlockDropType(slot))
+	s.dbClient.Persist(db.TransactionDropType(slot))
+	s.dbClient.Persist(db.WithdrawalDropType(slot))
+
 }

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -112,16 +112,8 @@ func (s *StateAnalyzer) runDownloadStatesFinalized(wgDownload *sync.WaitGroup) {
 				s.ReorgRewind(baseReorgEpoch - 1) // delete metrics from next and current state (check statequeue)
 			}
 
-		// case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
-		// 	// slot must be the last slot previous to the finalized epoch
-		// 	slot := phase0.Slot(newFinalCheckpoint.Epoch*spec.SlotsPerEpoch - 1)
-		// 	root := s.cli.RequestStateRoot(slot)
-		// 	finalEpoch, ok := queue.CheckFinalized(slot, root)
-
-		// 	if !ok {
-		// 		queue = NewStateQueue(slot, root)
-		// 		nextEpochDownload = finalEpoch
-		// 	}
+		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+			s.dbClient.Persist(db.ChepointTypeFromCheckpoint(newFinalCheckpoint))
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing state requester routine")

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -16,9 +16,11 @@ func (s *StateAnalyzer) runDownloadStates(wgDownload *sync.WaitGroup) {
 	// loop over the list of slots that we need to analyze
 
 	// We need three consecutive states to compute max rewards easier
-	prevBState := local_spec.AgnosticState{}
-	bstate := local_spec.AgnosticState{}
-	nextBstate := local_spec.AgnosticState{}
+	queue := StateQueue{
+		prevState:    local_spec.AgnosticState{},
+		currentState: local_spec.AgnosticState{},
+		nextState:    local_spec.AgnosticState{},
+	}
 loop:
 	for slot := s.initSlot; slot < s.finalSlot; slot += local_spec.SlotsPerEpoch {
 
@@ -33,11 +35,7 @@ loop:
 				break loop
 			}
 
-			err := s.DownloadNewState(&prevBState, &bstate, &nextBstate, phase0.Slot(slot), false)
-			if err != nil {
-				log.Errorf("error downloading state at slot %d: %s", slot, err)
-				return
-			}
+			s.DownloadNewState(&queue, phase0.Slot(slot), false)
 
 		}
 

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/db"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	local_spec "github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/utils"
@@ -95,16 +96,32 @@ func (s *StateAnalyzer) runDownloadStatesFinalized(wgDownload *sync.WaitGroup) {
 				nextEpochDownload += 1
 			}
 
-		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
-			// slot must be the last slot previous to the finalized epoch
-			slot := phase0.Slot(newFinalCheckpoint.Epoch*spec.SlotsPerEpoch - 1)
-			root := s.cli.RequestStateRoot(slot)
-			finalEpoch, ok := queue.CheckFinalized(slot, root)
+		case newReorg := <-s.eventsObj.ReorgChan:
+			s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))
+			headReorgEpoch := phase0.Epoch(newReorg.Slot / spec.SlotsPerEpoch)
+			baseReorgEpoch := phase0.Epoch((newReorg.Slot - phase0.Slot(newReorg.Depth)) / spec.SlotsPerEpoch)
 
-			if !ok {
+			// if the reorg is at the end of an epoch, or an epoch boundary has been crossed
+			if newReorg.Slot%spec.SlotsPerEpoch == 31 ||
+				headReorgEpoch > baseReorgEpoch {
+
+				slot, root := s.cli.GetFinalizedEndSlotStateRoot()
 				queue = NewStateQueue(slot, root)
-				nextEpochDownload = finalEpoch
+				nextEpochDownload = phase0.Epoch(slot / spec.SlotsPerEpoch)
+				log.Infof("rewinding to finalized %d", nextEpochDownload)
+				s.ReorgRewind(baseReorgEpoch - 1) // delete metrics from next and current state (check statequeue)
 			}
+
+		// case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+		// 	// slot must be the last slot previous to the finalized epoch
+		// 	slot := phase0.Slot(newFinalCheckpoint.Epoch*spec.SlotsPerEpoch - 1)
+		// 	root := s.cli.RequestStateRoot(slot)
+		// 	finalEpoch, ok := queue.CheckFinalized(slot, root)
+
+		// 	if !ok {
+		// 		queue = NewStateQueue(slot, root)
+		// 		nextEpochDownload = finalEpoch
+		// 	}
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing state requester routine")
@@ -152,4 +169,13 @@ func (s *StateAnalyzer) DownloadNewState(
 	}
 	// check if the min Request time has been completed (to avoid spaming the API)
 	<-ticker.C
+}
+
+func (s *StateAnalyzer) ReorgRewind(epoch phase0.Epoch) {
+
+	log.Infof("deleting epoch data from %d (included) onwards", epoch)
+	s.dbClient.Persist(db.EpochDropType(epoch))
+	s.dbClient.Persist(db.ProposerDutiesDropType(epoch))
+	s.dbClient.Persist(db.ValidatorRewardsDropType(epoch))
+
 }

--- a/pkg/analyzer/process_transactions.go
+++ b/pkg/analyzer/process_transactions.go
@@ -26,7 +26,7 @@ loop:
 				log.Warn("the transactions task channel has closed, finishing transaction routine")
 				return
 			}
-			log.Infof("transaction task received for slot %d, analyzing...", task.Slot)
+			log.Debugf("transaction task received for slot %d, analyzing...", task.Slot)
 
 			for _, tx := range task.Transactions {
 				s.dbClient.Persist(tx)

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -3,14 +3,17 @@ package analyzer
 import (
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	ValidatorSetSize = 500000 // Estimation of current number of validators, used for channel length declaration
-	maxWorkers       = 50
-	minBlockReqTime  = 100 * time.Millisecond // max 10 queries per second, dont spam beacon node
-	minStateReqTime  = 1 * time.Second        // max 1 query per second, dont spam beacon node
+	ValidatorSetSize           = 500000                 // Estimation of current number of validators, used for channel length declaration
+	maxWorkers                 = 50                     // maximum number of workers allowed in the tool
+	minBlockReqTime            = 100 * time.Millisecond // max 10 queries per second, dont spam beacon node
+	minStateReqTime            = 1 * time.Second        // max 1 query per second, dont spam beacon node
+	epochsToFinalizedTentative = 3                      // usually, 3 full epochs before the head it is finalized
 )
 
 var (
@@ -18,3 +21,86 @@ var (
 		"module", "analyzer",
 	)
 )
+
+type SlotRoot struct {
+	Slot  phase0.Slot
+	Epoch phase0.Epoch
+	Root  phase0.Root
+}
+
+type StateQueue struct {
+	prevState       spec.AgnosticState
+	currentState    spec.AgnosticState
+	nextState       spec.AgnosticState
+	Roots           []SlotRoot
+	LatestFinalized SlotRoot
+}
+
+func NewStateQueue() StateQueue {
+	return StateQueue{
+		prevState:    spec.AgnosticState{},
+		currentState: spec.AgnosticState{},
+		nextState:    spec.AgnosticState{},
+		Roots:        make([]SlotRoot, 0),
+	}
+}
+
+func (s *StateQueue) AddNewState(newState spec.AgnosticState) {
+
+	if s.nextState.Epoch != phase0.Epoch(0) && newState.Epoch != s.nextState.Epoch+1 {
+		log.Panicf("state at epoch %d is not consecutive to %d...", newState.Epoch, s.nextState.Epoch)
+	}
+
+	s.prevState = s.currentState
+	s.currentState = s.nextState
+	s.nextState = newState
+
+	s.AddRoot(newState.Slot, newState.StateRoot)
+}
+
+func (s StateQueue) Complete() bool {
+	emptyRoot := phase0.Root{}
+	if s.prevState.StateRoot != emptyRoot {
+		return true
+	}
+	return false
+}
+
+func (s *StateQueue) AddRoot(iSlot phase0.Slot, iRoot phase0.Root) {
+	s.Roots = append(s.Roots, SlotRoot{
+		Slot:  iSlot,
+		Epoch: phase0.Epoch(iSlot / spec.SlotsPerEpoch),
+		Root:  iRoot,
+	})
+}
+
+func (s *StateQueue) CheckFinalized(iSlot phase0.Slot, iRoot phase0.Root) (phase0.Epoch, bool) {
+
+	if s.LatestFinalized.Epoch == 0 {
+		// it has not been configured yet
+		s.LatestFinalized = s.Roots[0] // the first position of our history should be the latest finalized
+	}
+
+	// SlotRoots are ordered ascending always
+	for i, slotRoot := range s.Roots {
+		if slotRoot.Slot == iSlot { // found it in our history
+			if slotRoot.Root == iRoot { // the root matches, finalized ok
+				s.Roots = s.Roots[i+1:] // remove all roots before this one, they are ordered asc
+
+				s.LatestFinalized = slotRoot
+				log.Infof("finalized checkpoint at epoch %d successfully verified...", slotRoot.Epoch)
+				return slotRoot.Epoch, true
+			} else { // we found the slot in the history, but the root does not match
+				log.Errorf("the finalized checkpoint was not verfied, probably a reorg happened...")
+				log.Errorf("rewinding to epoch %d", s.LatestFinalized.Epoch-2)
+				return s.LatestFinalized.Epoch - 2, false // go 2 epochs before the finalized
+
+			}
+		}
+	}
+	// the slot does not exist in our history
+	// continue as normal
+
+	return s.LatestFinalized.Epoch, true
+
+}

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -36,12 +36,17 @@ type StateQueue struct {
 	LatestFinalized SlotRoot
 }
 
-func NewStateQueue() StateQueue {
+func NewStateQueue(finalizedSlot phase0.Slot, finalizedRoot phase0.Root) StateQueue {
 	return StateQueue{
 		prevState:    spec.AgnosticState{},
 		currentState: spec.AgnosticState{},
 		nextState:    spec.AgnosticState{},
 		Roots:        make([]SlotRoot, 0),
+		LatestFinalized: SlotRoot{
+			Slot:  finalizedSlot,
+			Epoch: phase0.Epoch(finalizedSlot / spec.SlotsPerEpoch),
+			Root:  finalizedRoot,
+		},
 	}
 }
 

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -23,9 +23,9 @@ var (
 )
 
 type SlotRoot struct {
-	Slot  phase0.Slot
-	Epoch phase0.Epoch
-	Root  phase0.Root
+	Slot      phase0.Slot
+	Epoch     phase0.Epoch
+	StateRoot phase0.Root
 }
 
 type StateQueue struct {
@@ -43,9 +43,9 @@ func NewStateQueue(finalizedSlot phase0.Slot, finalizedRoot phase0.Root) StateQu
 		nextState:    spec.AgnosticState{},
 		Roots:        make([]SlotRoot, 0),
 		LatestFinalized: SlotRoot{
-			Slot:  finalizedSlot,
-			Epoch: phase0.Epoch(finalizedSlot / spec.SlotsPerEpoch),
-			Root:  finalizedRoot,
+			Slot:      finalizedSlot,
+			Epoch:     phase0.Epoch(finalizedSlot / spec.SlotsPerEpoch),
+			StateRoot: finalizedRoot,
 		},
 	}
 }
@@ -73,9 +73,9 @@ func (s StateQueue) Complete() bool {
 
 func (s *StateQueue) AddRoot(iSlot phase0.Slot, iRoot phase0.Root) {
 	s.Roots = append(s.Roots, SlotRoot{
-		Slot:  iSlot,
-		Epoch: phase0.Epoch(iSlot / spec.SlotsPerEpoch),
-		Root:  iRoot,
+		Slot:      iSlot,
+		Epoch:     phase0.Epoch(iSlot / spec.SlotsPerEpoch),
+		StateRoot: iRoot,
 	})
 }
 
@@ -89,7 +89,7 @@ func (s *StateQueue) CheckFinalized(iSlot phase0.Slot, iRoot phase0.Root) (phase
 	// SlotRoots are ordered ascending always
 	for i, slotRoot := range s.Roots {
 		if slotRoot.Slot == iSlot { // found it in our history
-			if slotRoot.Root == iRoot { // the root matches, finalized ok
+			if slotRoot.StateRoot == iRoot { // the root matches, finalized ok
 				s.Roots = s.Roots[i+1:] // remove all roots before this one, they are ordered asc
 
 				s.LatestFinalized = slotRoot

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -2,6 +2,7 @@ package clientapi
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -90,4 +91,12 @@ func (s APIClient) RequestBlockByHash(hash common.Hash) (*types.Block, error) {
 		return nil, fmt.Errorf("unable to retrieve block by hash %s: %s", hash.String(), err.Error())
 	}
 	return block, nil
+}
+func (s APIClient) RequestCurrentHead() phase0.Slot {
+	head, err := s.Api.BeaconBlockHeader(s.ctx, "head")
+	if err != nil {
+		log.Panicf("could not request current head: %s", err)
+	}
+
+	return head.Header.Message.Slot
 }

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -40,6 +40,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, boo
 		customBlock.Size = uint32(block.Size())
 	}
 
+	customBlock.StateRoot = s.RequestStateRoot(slot)
 	return customBlock, true, nil
 }
 

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -26,3 +26,12 @@ func (s APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticSta
 
 	return &resultState, nil
 }
+
+func (s APIClient) RequestStateRoot(slot phase0.Slot) phase0.Root {
+	root, err := s.Api.BeaconStateRoot(s.ctx, fmt.Sprintf("%d", slot))
+	if err != nil {
+		log.Panicf("could not download the state root at %d: %s", slot, err)
+	}
+
+	return *root
+}

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -10,11 +10,11 @@ import (
 func (s APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticState, error) {
 	newState, err := s.Api.BeaconState(s.ctx, fmt.Sprintf("%d", slot))
 	if newState == nil {
-		return nil, fmt.Errorf("unable to retrieve Finalized Beacon State from the beacon node, closing requester routine. nil State")
+		return nil, fmt.Errorf("unable to retrieve Beacon State from the beacon node, closing requester routine. nil State")
 	}
 	if err != nil {
 		// close the channel (to tell other routines to stop processing and end)
-		return nil, fmt.Errorf("unable to retrieve Finalized Beacon State from the beacon node, closing requester routine. %s", err.Error())
+		return nil, fmt.Errorf("unable to retrieve Beacon State from the beacon node, closing requester routine. %s", err.Error())
 
 	}
 

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -23,6 +23,9 @@ func (s APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticSta
 		// close the channel (to tell other routines to stop processing and end)
 		return nil, fmt.Errorf("unable to open beacon state, closing requester routine. %s", err.Error())
 	}
+	// We have used HashTreeRoot method to hash the downloaded state, but it does not work ok
+	// meantime, we use this
+	resultState.StateRoot = s.RequestStateRoot(slot)
 
 	return &resultState, nil
 }

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -38,3 +38,20 @@ func (s APIClient) RequestStateRoot(slot phase0.Slot) phase0.Root {
 
 	return *root
 }
+
+// Finalized Checkpoints happen at the beginning of an epoch
+// This method returns the finalized slot at the end of an epoch
+// Usually, it is the slot before the finalized one
+func (s APIClient) GetFinalizedEndSlotStateRoot() (phase0.Slot, phase0.Root) {
+	currentFinalized, err := s.Api.Finality(s.ctx, "head")
+
+	if err != nil {
+		log.Panicf("could not determine the current finalized checkpoint")
+	}
+
+	finalizedSlot := phase0.Slot(currentFinalized.Finalized.Epoch*local_spec.SlotsPerEpoch - 1)
+
+	root := s.RequestStateRoot(finalizedSlot)
+
+	return finalizedSlot, root
+}

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -43,10 +43,15 @@ var (
 		DO NOTHING;
 	`
 	SelectLastSlot = `
-	SELECT f_slot
-	FROM t_block_metrics
-	ORDER BY f_slot DESC
-	LIMIT 1`
+		SELECT f_slot
+		FROM t_block_metrics
+		ORDER BY f_slot DESC
+		LIMIT 1`
+
+	DropBlocksQuery = `
+		DELETE FROM t_block_metrics
+		WHERE f_slot >= $1;
+`
 )
 
 func insertBlock(inputBlock spec.AgnosticBlock) (string, []interface{}) {
@@ -95,4 +100,16 @@ func (p *PostgresDBService) ObtainLastSlot() (phase0.Slot, error) {
 	rows.Scan(&slot)
 	rows.Close()
 	return phase0.Slot(slot), nil
+}
+
+type BlockDropType phase0.Slot
+
+func (s BlockDropType) Type() spec.ModelType {
+	return spec.BlockDropModel
+}
+
+func DropBlocks(slot BlockDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropBlocksQuery, resultArgs
 }

--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -47,6 +47,11 @@ var (
 		FROM t_epoch_metrics_summary
 		ORDER BY f_epoch DESC
 		LIMIT 1`
+
+	DropEpochsQuery = `
+	DELETE FROM t_epoch_metrics_summary
+	WHERE f_epoch >= $1;
+`
 )
 
 func insertEpoch(inputEpoch spec.Epoch) (string, []interface{}) {
@@ -85,4 +90,16 @@ func (p *PostgresDBService) ObtainLastEpoch() (phase0.Epoch, error) {
 	rows.Scan(&epoch)
 	rows.Close()
 	return phase0.Epoch(epoch), nil
+}
+
+type EpochDropType phase0.Epoch
+
+func (s EpochDropType) Type() spec.ModelType {
+	return spec.EpochDropModel
+}
+
+func DropEpochs(epoch EpochDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropEpochsQuery, resultArgs
 }

--- a/pkg/db/finalized.go
+++ b/pkg/db/finalized.go
@@ -1,0 +1,55 @@
+package db
+
+/*
+
+This file together with the model, has all the needed methods to interact with the epoch_metrics table of the database
+
+*/
+
+import (
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+// Postgres intregration variables
+var (
+	InsertFinalizedQuery = `
+	INSERT INTO t_finalized_checkpoint (
+		f_id,
+		f_block_root,
+		f_state_root,
+		f_epoch)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT ON CONSTRAINT t_finalized_checkpoint_pkey
+		DO 
+			UPDATE SET 
+			f_block_root = excluded.f_block_root,
+			f_state_root = excluded.f_state_root,
+			f_epoch = excluded.f_epoch;
+	`
+)
+
+func InsertCheckpoint(inputCheckpoint CheckpointType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+
+	resultArgs = append(resultArgs, 0) // hardcoded, ID is always 0
+	resultArgs = append(resultArgs, inputCheckpoint.Block.String())
+	resultArgs = append(resultArgs, inputCheckpoint.State.String())
+	resultArgs = append(resultArgs, inputCheckpoint.Epoch)
+
+	return InsertFinalizedQuery, resultArgs
+}
+
+type CheckpointType api.FinalizedCheckpointEvent
+
+func (s CheckpointType) Type() spec.ModelType {
+	return spec.FinalizedCheckpointModel
+}
+
+func ChepointTypeFromCheckpoint(input api.FinalizedCheckpointEvent) CheckpointType {
+	return CheckpointType{
+		Block: input.Block,
+		State: input.State,
+		Epoch: input.Epoch,
+	}
+}

--- a/pkg/db/migrations/000013_create_reorg_table.down.sql
+++ b/pkg/db/migrations/000013_create_reorg_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_reorgs;

--- a/pkg/db/migrations/000013_create_reorg_table.up.sql
+++ b/pkg/db/migrations/000013_create_reorg_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS t_reorgs(
+	f_slot INT PRIMARY KEY,
+	f_depth INT,
+	f_old_head_block_root TEXT,
+	f_new_head_block_root TEXT,
+	f_old_head_state_root TEXT,
+	f_new_head_state_root TEXT);

--- a/pkg/db/migrations/000014_create_checkpoint_table.down.sql
+++ b/pkg/db/migrations/000014_create_checkpoint_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_finalized_checkpoint;

--- a/pkg/db/migrations/000014_create_checkpoint_table.up.sql
+++ b/pkg/db/migrations/000014_create_checkpoint_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS t_finalized_checkpoint(
+	f_id INT PRIMARY KEY,
+	f_block_root TEXT,
+	f_state_root TEXT,
+	f_epoch INT);

--- a/pkg/db/proposer_duties.go
+++ b/pkg/db/proposer_duties.go
@@ -7,6 +7,7 @@ This file together with the model, has all the needed methods to interact with t
 */
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -21,6 +22,11 @@ var (
 		ON CONFLICT DO NOTHING;
 	`
 	// if there is a confilct the line already exists
+
+	DropProposerDutiesQuery = `
+	DELETE FROM t_proposer_duties
+	WHERE f_proposer_slot/32 >= $1;
+`
 )
 
 func insertProposerDuty(inputDuty spec.ProposerDuty) (string, []interface{}) {
@@ -37,4 +43,16 @@ func ProposerDutyOperation(inputDuty spec.ProposerDuty) (string, []interface{}) 
 	q, args := insertProposerDuty(inputDuty)
 	return q, args
 
+}
+
+type ProposerDutiesDropType phase0.Epoch
+
+func (s ProposerDutiesDropType) Type() spec.ModelType {
+	return spec.ProposerDutyDropModel
+}
+
+func DropProposerDuties(epoch ProposerDutiesDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropProposerDutiesQuery, resultArgs
 }

--- a/pkg/db/reorg.go
+++ b/pkg/db/reorg.go
@@ -1,0 +1,58 @@
+package db
+
+/*
+
+This file together with the model, has all the needed methods to interact with the epoch_metrics table of the database
+
+*/
+
+import (
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+// Postgres intregration variables
+var (
+	InsertReorgQuery = `
+	INSERT INTO t_reorgs (
+		f_slot,
+		f_depth,
+		f_old_head_block_root,
+		f_new_head_block_root,
+		f_old_head_state_root,
+		f_new_head_state_root)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT ON CONSTRAINT t_reorgs_pkey
+		DO NOTHING;
+	`
+)
+
+func InsertReorg(inputReorg ReorgType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+
+	resultArgs = append(resultArgs, inputReorg.Slot)
+	resultArgs = append(resultArgs, inputReorg.Depth)
+	resultArgs = append(resultArgs, inputReorg.OldHeadBlock.String())
+	resultArgs = append(resultArgs, inputReorg.NewHeadBlock.String())
+	resultArgs = append(resultArgs, inputReorg.OldHeadState.String())
+	resultArgs = append(resultArgs, inputReorg.NewHeadState.String())
+
+	return InsertReorgQuery, resultArgs
+}
+
+type ReorgType api.ChainReorgEvent
+
+func (s ReorgType) Type() spec.ModelType {
+	return spec.ReorgModel
+}
+
+func ReorgTypeFromReorg(input api.ChainReorgEvent) ReorgType {
+	return ReorgType{
+		Slot:         input.Slot,
+		Depth:        input.Depth,
+		OldHeadBlock: input.OldHeadBlock,
+		NewHeadBlock: input.NewHeadBlock,
+		OldHeadState: input.OldHeadState,
+		NewHeadState: input.NewHeadState,
+	}
+}

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -188,6 +188,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := InsertReorg(task.(ReorgType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.FinalizedCheckpointModel:
+						q, args := InsertCheckpoint(task.(CheckpointType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					default:
 						err = fmt.Errorf("could not figure out the type of write task")
 						wlog.Errorf("could not process incoming task, %s", err)

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -132,8 +132,16 @@ func (p *PostgresDBService) runWriters() {
 						q, args := BlockOperation(task.(spec.AgnosticBlock))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.BlockDropModel:
+						q, args := DropBlocks(task.(BlockDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.EpochModel:
 						q, args := EpochOperation(task.(spec.Epoch))
+						persis.query = q
+						persis.values = append(persis.values, args...)
+					case spec.EpochDropModel:
+						q, args := DropEpochs(task.(EpochDropType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
 					case spec.PoolSummaryModel:
@@ -144,6 +152,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := ProposerDutyOperation(task.(spec.ProposerDuty))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.ProposerDutyDropModel:
+						q, args := DropProposerDuties(task.(ProposerDutiesDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.ValidatorLastStatusModel:
 						q, args := ValidatorLastStatusOperation(task.(spec.ValidatorLastStatus))
 						persis.query = q
@@ -152,12 +164,28 @@ func (p *PostgresDBService) runWriters() {
 						q, args := ValidatorOperation(task.(spec.ValidatorRewards))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.ValidatorRewardDropModel:
+						q, args := DropValidatorRewards(task.(ValidatorRewardsDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.WithdrawalModel:
 						q, args := WithdrawalOperation(task.(spec.Withdrawal))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.WithdrawalDropModel:
+						q, args := DropWitdrawals(task.(WithdrawalDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.TransactionsModel:
 						q, args := TransactionOperation(task.(*spec.AgnosticTransaction))
+						persis.query = q
+						persis.values = append(persis.values, args...)
+					case spec.TransactionDropModel:
+						q, args := DropTransactions(task.(TransactionDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
+					case spec.ReorgModel:
+						q, args := InsertReorg(task.(ReorgType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
 					default:

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -1,16 +1,22 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
 var (
 	UpsertTransaction = `
-INSERT INTO t_transactions(
-	f_tx_type, f_chain_id, f_data, f_gas, f_gas_price, f_gas_tip_cap, f_gas_fee_cap, f_value, f_nonce, f_to, f_hash,
-                           f_size, f_slot, f_el_block_number, f_timestamp, f_from, f_contract_address)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-ON CONFLICT DO NOTHING;`
+		INSERT INTO t_transactions(
+			f_tx_type, f_chain_id, f_data, f_gas, f_gas_price, f_gas_tip_cap, f_gas_fee_cap, f_value, f_nonce, f_to, f_hash,
+								f_size, f_slot, f_el_block_number, f_timestamp, f_from, f_contract_address)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		ON CONFLICT DO NOTHING;`
+
+	DropTransactionsQuery = `
+		DELETE FROM t_transactions
+		WHERE f_slot >= $1;
+`
 )
 
 /**
@@ -50,4 +56,16 @@ func TransactionOperation(transaction *spec.AgnosticTransaction) (string, []inte
 	q, args := insertTransaction(transaction)
 
 	return q, args
+}
+
+type TransactionDropType phase0.Slot
+
+func (s TransactionDropType) Type() spec.ModelType {
+	return spec.TransactionDropModel
+}
+
+func DropTransactions(slot TransactionDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropTransactionsQuery, resultArgs
 }

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -39,9 +40,9 @@ var (
 				f_status = excluded.f_status;
 	`
 
-	Drop = `
+	DropValidatorRewardsQuery = `
 		DROP FROM t_validator_rewards_summary
-		WHERE f_val_idx = $1 AND f_epoch = $2;
+		WHERE f_epoch >= $1;
 	`
 )
 
@@ -68,4 +69,16 @@ func ValidatorOperation(inputValidator spec.ValidatorRewards) (string, []interfa
 
 	q, args := insertValidator(inputValidator)
 	return q, args
+}
+
+type ValidatorRewardsDropType phase0.Epoch
+
+func (s ValidatorRewardsDropType) Type() spec.ModelType {
+	return spec.ValidatorRewardDropModel
+}
+
+func DropValidatorRewards(epoch ValidatorRewardsDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropValidatorRewardsQuery, resultArgs
 }

--- a/pkg/db/withdrawals.go
+++ b/pkg/db/withdrawals.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -21,6 +22,11 @@ var (
 			f_address = excluded.f_address,
 			f_amount = excluded.f_amount;
 	`
+
+	DropWithdrawalsQuery = `
+		DELETE FROM t_withdrawals
+		WHERE f_slot >= $1;
+`
 )
 
 func insertWithdrawal(inputWithdrawal spec.Withdrawal) (string, []interface{}) {
@@ -38,4 +44,16 @@ func WithdrawalOperation(inputWithdrawal spec.Withdrawal) (string, []interface{}
 
 	q, args := insertWithdrawal(inputWithdrawal)
 	return q, args
+}
+
+type WithdrawalDropType phase0.Slot
+
+func (s WithdrawalDropType) Type() spec.ModelType {
+	return spec.WithdrawalDropModel
+}
+
+func DropWitdrawals(slot WithdrawalDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropWithdrawalsQuery, resultArgs
 }

--- a/pkg/events/finalized_checkpoint.go
+++ b/pkg/events/finalized_checkpoint.go
@@ -1,0 +1,27 @@
+package events
+
+import api "github.com/attestantio/go-eth2-client/api/v1"
+
+func (e *Events) SubscribeToFinalizedCheckpointEvents() {
+	// subscribe to head event
+	err := e.cli.Api.Events(e.ctx, []string{"finalized_checkpoint"}, e.HandleCheckpointEvent) // every new head
+	if err != nil {
+		log.Panicf("failed to subscribe to head events: %s", err)
+	}
+	log.Infof("subscribed to finalized checkpoint events")
+}
+
+func (e *Events) HandleCheckpointEvent(event *api.Event) {
+	log := log.WithField("routine", "checkpoint-event")
+	if event.Data == nil {
+		return
+	}
+
+	data := event.Data.(*api.FinalizedCheckpointEvent) // cast to head event
+	log.Infof("Received a new event: epoch %d, slot root: %s", data.Epoch, data.State.String())
+
+	select { // only notify if we can
+	case e.FinalizedChan <- *data:
+	default:
+	}
+}

--- a/pkg/events/finalized_checkpoint.go
+++ b/pkg/events/finalized_checkpoint.go
@@ -18,7 +18,7 @@ func (e *Events) HandleCheckpointEvent(event *api.Event) {
 	}
 
 	data := event.Data.(*api.FinalizedCheckpointEvent) // cast to head event
-	log.Infof("Received a new event: epoch %d, slot root: %s", data.Epoch, data.State.String())
+	log.Infof("Received a new event: epoch %d, state root: %s", data.Epoch, data.State.String())
 
 	select { // only notify if we can
 	case e.FinalizedChan <- *data:

--- a/pkg/events/finalized_checkpoint.go
+++ b/pkg/events/finalized_checkpoint.go
@@ -4,9 +4,9 @@ import api "github.com/attestantio/go-eth2-client/api/v1"
 
 func (e *Events) SubscribeToFinalizedCheckpointEvents() {
 	// subscribe to head event
-	err := e.cli.Api.Events(e.ctx, []string{"finalized_checkpoint"}, e.HandleCheckpointEvent) // every new head
+	err := e.cli.Api.Events(e.ctx, []string{"finalized_checkpoint"}, e.HandleCheckpointEvent) // every new checkpoint
 	if err != nil {
-		log.Panicf("failed to subscribe to head events: %s", err)
+		log.Panicf("failed to subscribe to finalized checkpoint events: %s", err)
 	}
 	log.Infof("subscribed to finalized checkpoint events")
 }

--- a/pkg/events/reorg.go
+++ b/pkg/events/reorg.go
@@ -1,0 +1,24 @@
+package events
+
+import api "github.com/attestantio/go-eth2-client/api/v1"
+
+func (e *Events) SubscribeToReorgsEvents() {
+	// subscribe to head event
+	err := e.cli.Api.Events(e.ctx, []string{"chain_reorg"}, e.HandleReorgEvent) // every reorg
+	if err != nil {
+		log.Panicf("failed to subscribe to chain_reorg events: %s", err)
+	}
+	log.Infof("subscribed to chain_reorg events")
+}
+
+func (e *Events) HandleReorgEvent(event *api.Event) {
+	log := log.WithField("routine", "reorg-event")
+	if event.Data == nil {
+		return
+	}
+
+	data := event.Data.(*api.ChainReorgEvent) // cast to head event
+	log.Infof("Received a new event: slot %d of depth %d", data.Slot, data.Depth)
+
+	e.ReorgChan <- *data
+}

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -23,6 +23,7 @@ type Events struct {
 
 	SubscribedFinalized bool
 	FinalizedChan       chan api.FinalizedCheckpointEvent
+	ReorgChan           chan api.ChainReorgEvent
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
@@ -33,5 +34,6 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		HeadChan:            make(chan phase0.Slot),
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
+		ReorgChan:           make(chan api.ChainReorgEvent),
 	}
 }

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 
+	api "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
 	"github.com/sirupsen/logrus"
@@ -19,13 +20,18 @@ type Events struct {
 	cli            *clientapi.APIClient
 	SubscribedHead bool
 	HeadChan       chan phase0.Slot
+
+	SubscribedFinalized bool
+	FinalizedChan       chan api.FinalizedCheckpointEvent
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 	return Events{
-		ctx:            iCtx,
-		cli:            iCli,
-		SubscribedHead: false,
-		HeadChan:       make(chan phase0.Slot),
+		ctx:                 iCtx,
+		cli:                 iCli,
+		SubscribedHead:      false,
+		HeadChan:            make(chan phase0.Slot),
+		SubscribedFinalized: false,
+		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
 	}
 }

--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -13,6 +13,7 @@ import (
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
 type AgnosticBlock struct {
 	Slot              phase0.Slot
+	StateRoot         phase0.Root
 	ProposerIndex     phase0.ValidatorIndex
 	Graffiti          [32]byte
 	Proposed          bool

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -53,6 +53,7 @@ const (
 	TransactionsModel
 	TransactionDropModel
 	ReorgModel
+	FinalizedCheckpointModel
 )
 
 type ValidatorStatus int8

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -39,13 +39,20 @@ type ModelType int8
 
 const (
 	BlockModel ModelType = iota
+	BlockDropModel
 	EpochModel
+	EpochDropModel
 	PoolSummaryModel
 	ProposerDutyModel
+	ProposerDutyDropModel
 	ValidatorLastStatusModel
 	ValidatorRewardsModel
+	ValidatorRewardDropModel
 	WithdrawalModel
+	WithdrawalDropModel
 	TransactionsModel
+	TransactionDropModel
+	ReorgModel
 )
 
 type ValidatorStatus int8

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -13,6 +13,7 @@ import (
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
 type AgnosticState struct {
 	Version                 spec.DataVersion
+	StateRoot               phase0.Root
 	Balances                []phase0.Gwei                     // balance of each validator
 	Validators              []*phase0.Validator               // list of validators
 	TotalActiveBalance      phase0.Gwei                       // effective balance


### PR DESCRIPTION
# Motivation
Right now the tool follows the chain head and downloads new states just at the epoch before the head. 
However, in the case of a big reorg, the tool could be using states and blocks from a small fork, which does not belong to the canonical chain.

# Description
The tool will continue to download the states and blocks at the epoch before the head, but will track reorgs and finalized states. When a reorg happens, the tool rewinds to the depth of the reorg and redownloads data as needed.

# TODOs

- [x] Track finalized states
- [x] Track reorgs
- [x] Rewind on reorg
- [x] Store finalized and reorg events in the database 


# Future Work

It may be interesting to double check each of the downloaded checkpoints for both state and block.

# Epoch logs
```
Eth2 State Analyzer v0.0.1
analyzer-rewards_1  | time="2023-07-10T07:01:13Z" level=info msg="Pending slots for new epoch: 14" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:01:38Z" level=info msg="Received a new event: slot 6038708, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:01:38Z" level=info msg="Pending slots for new epoch: 12" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:01:49Z" level=info msg="Received a new event: slot 6038709, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:01:49Z" level=info msg="Pending slots for new epoch: 11" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:00Z" level=info msg="Received a new event: slot 6038710, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:00Z" level=info msg="Pending slots for new epoch: 10" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:14Z" level=info msg="Received a new event: slot 6038711, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:14Z" level=info msg="Pending slots for new epoch: 9" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:25Z" level=info msg="Received a new event: slot 6038712, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:25Z" level=info msg="Pending slots for new epoch: 8" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:48Z" level=info msg="Received a new event: slot 6038714, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:02:48Z" level=info msg="Pending slots for new epoch: 6" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:01Z" level=info msg="Received a new event: slot 6038715, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:01Z" level=info msg="Pending slots for new epoch: 5" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:26Z" level=info msg="Received a new event: slot 6038717, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:26Z" level=info msg="Pending slots for new epoch: 3" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:49Z" level=info msg="Received a new event: slot 6038719, epoch 188709" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:49Z" level=info msg="Pending slots for new epoch: 1" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:03:59Z" level=info msg="Received a new event: epoch 188708, state root: 0x744b3bcca06410388b89b130f3d5e569efc38e5f181da329ad3be388aa9c7f05" module=Events routine=checkpoint-event
analyzer-rewards_1  | time="2023-07-10T07:04:14Z" level=info msg="Received a new event: slot 6038721, epoch 188710" module=Events routine=head-event
analyzer-rewards_1  | time="2023-07-10T07:04:14Z" level=info msg="Pending slots for new epoch: 31" module=Events routine=head-event
```

## Example of block not verified

```
analyzer-blocks_1   | time="2023-07-07T08:27:26Z" level=info msg="block task received for slot 6017536, analyzing..." module=analyzer
analyzer-blocks_1   | time="2023-07-07T08:27:28Z" level=info msg="Received a new event: slot 6017537, epoch 188048" module=Events routine=head-event
analyzer-blocks_1   | time="2023-07-07T08:27:28Z" level=info msg="Pending slots for new epoch: 31" module=Events routine=head-event
analyzer-blocks_1   | time="2023-07-07T08:27:28Z" level=info msg="Received a new event: slot 6017537 of depth 1" module=Events routine=reorg-event
analyzer-blocks_1   | time="2023-07-07T08:27:28Z" level=warning msg="unable to retrieve transaction receipt for hash 68537ba8292cefdd684a372914af1cb503bec55551d6fb507113caf016cb170c: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 0247d9078caa129c8bd0896088285c93862d99d55789f176340077d15b9a1be3: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash e0cb14df4eed9aa061e39578060955ea24cac5fd38c8caf717b9c9f0f0f57e23: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 59c71ea2bb527a1d2ef9ef38dbfd43b322969f92fd35d68e4f63b91cfbad82a8: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash eb58be72037b4dbd45cfe752cd2fd4fc27d88afc4b490b81d670d3b312d13206: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash fbb767c759aacb92c619b9e2295045ad82b2ad85feaeb27edc7719d90e897cb7: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash ed8d2a255a3d3c68745717e15456f3950e37d19496b455543822714360f1ea06: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 4ad54a176c3055fc29dba85cf88857d310d78d5c5887f2782ff715bef30139e5: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash b703dd84a816b3835c3127cbd310d279ee3650406a034834320568582d3a0e27: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 241d0790d1a092b65b9d77fe65f8c4c3d8c6240b43eda8e565c48a7905e79f36: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 6f433b5ba389dc19efbddfb0ba341bb61df929355c855b3d78025ee75bd46dcc: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash ed0558eac59d99b5f8311837bd658823699eab468e83a1dc212e0835856dea1b: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash b77a75f65bec52b4c523b023d3286bc82ac66283c50bd6d3a7ea4bcb5d361101: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 816e7058d5dd350a22d67fd67a4502150e202b452a1acb7cf53e40679dff73a8: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 1b428bd1f80431adc6932e61fefcb42b3bc84125711b4aa93f278e2970e7e4ff: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash e4c1605e9bd45f53c55307d8a3d840a85a4f8f2477b3f065fbc82481b93b8cee: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash ea654dab51c29c46370b6b7d367f3121f98db6e81e2ad3119f3e5c5dc4f1937b: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash d3ed9da2cc387e8020e810a69376815498c2fd2ad01d519a0bdeafdfd9d1c1f3: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash cd84dd2e9d6b995e3a0ac60d06f9da6681b2929510b904d782c207458e00aa58: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash df8956de9a82232edb1e43f132386dbe2615164ce57180638a0b4778f715dd4c: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:30Z" level=warning msg="unable to retrieve transaction receipt for hash 5c35cb673c4974f6945eccc02909c0f208cf379d905bda80126619264204d419: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash 39df0e767c5a442cdbae3faeb3bbc7e5e5eafd4074b712044983fb279172b446: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash 41ffe08ec36a17a8698c110775f9f8851fd3aef6119e1b58b97ca4e7eb63d796: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash 0e6b46f327dd63712c43a893a02f7205826a65b4e22665f5d177c8b5eedeec6b: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash 45405f056067e12667cc8dbbea07e3c2409d19dacb7fd3834f5d7178f4432cd1: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash cc693503dd570bcfded6bc05ade2d4ff6620019e41c5a9529677a5f2314fa05a: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash dc92e58bb96ba802765fe78f13110184d3d30b0b51269738223c55268454c437: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash c99e43aa7ca0272b383e03042b9419ffc62b85a75c6fee6c617dce1306ad12ad: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash 604480edb63dc1e17b627b89cba1e1458d3a743a9d11978b1db0dbc3e4961081: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=warning msg="unable to retrieve transaction receipt for hash de3eb485a48613ecb77322256b3c2b86bb7be023782dd93e51c11b377a42ab68: not found" module=
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=info msg="rewinding to 6017536" module=analyzer
analyzer-blocks_1   | time="2023-07-07T08:27:31Z" level=info msg="deleting block data from 6017537 (included) onwards" module=analyzer
analyzer-blocks_1   | time="2023-07-07T08:27:39Z" level=info msg="Received a new event: slot 6017538, epoch 188048" module=Events routine=head-event
```