### PR TITLE
Track reorgs and redownload accordingly

### DIFF
--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -96,7 +96,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 		// 	// slot must be the last slot previous to the finalized epoch
 
 		case newReorg := <-s.eventsObj.ReorgChan:
-			log.Info("rewinding to %d", newReorg.Slot-phase0.Slot(newReorg.Depth))
+			log.Infof("rewinding to %d", newReorg.Slot-phase0.Slot(newReorg.Depth))
 
 			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth)
 			s.ReorgRewind(nextSlotDownload)
@@ -152,6 +152,7 @@ func (s BlockAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Sl
 
 func (s *BlockAnalyzer) ReorgRewind(slot phase0.Slot) {
 
+	log.Infof("deleting block data from %d (included) onwards", slot)
 	s.dbClient.Persist(db.BlockDropType(slot))
 	s.dbClient.Persist(db.TransactionDropType(slot))
 	s.dbClient.Persist(db.WithdrawalDropType(slot))

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -83,7 +83,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 			// make the block query
 			log.Infof("received new head signal: %d", headSlot)
 
-			for nextSlotDownload < headSlot {
+			for nextSlotDownload <= headSlot {
 				log.Infof("downloading block: %d", nextSlotDownload)
 				s.DownloadNewBlock(&rootHistory, phase0.Slot(nextSlotDownload))
 				nextSlotDownload = nextSlotDownload + 1
@@ -98,7 +98,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 		case newReorg := <-s.eventsObj.ReorgChan:
 			log.Infof("rewinding to %d", newReorg.Slot-phase0.Slot(newReorg.Depth))
 
-			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth)
+			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth) + 1
 			s.ReorgRewind(nextSlotDownload)
 
 		case <-s.ctx.Done():

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -96,6 +96,7 @@ func (s *BlockAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 		// 	// slot must be the last slot previous to the finalized epoch
 
 		case newReorg := <-s.eventsObj.ReorgChan:
+			s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))
 			log.Infof("rewinding to %d", newReorg.Slot-phase0.Slot(newReorg.Depth))
 
 			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth) + 1

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -95,16 +95,16 @@ func (s *StateAnalyzer) runDownloadStatesFinalized(wgDownload *sync.WaitGroup) {
 				nextEpochDownload += 1
 			}
 
-		case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
-			// slot must be the last slot previous to the finalized epoch
-			slot := phase0.Slot(newFinalCheckpoint.Epoch*spec.SlotsPerEpoch - 1)
-			root := s.cli.RequestStateRoot(slot)
-			finalEpoch, ok := queue.CheckFinalized(slot, root)
+		// case newFinalCheckpoint := <-s.eventsObj.FinalizedChan:
+		// 	// slot must be the last slot previous to the finalized epoch
+		// 	slot := phase0.Slot(newFinalCheckpoint.Epoch*spec.SlotsPerEpoch - 1)
+		// 	root := s.cli.RequestStateRoot(slot)
+		// 	finalEpoch, ok := queue.CheckFinalized(slot, root)
 
-			if !ok {
-				queue = NewStateQueue(slot, root)
-				nextEpochDownload = finalEpoch
-			}
+		// 	if !ok {
+		// 		queue = NewStateQueue(slot, root)
+		// 		nextEpochDownload = finalEpoch
+		// 	}
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing state requester routine")

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -97,6 +97,7 @@ func (s *StateAnalyzer) runDownloadStatesFinalized(wgDownload *sync.WaitGroup) {
 			}
 
 		case newReorg := <-s.eventsObj.ReorgChan:
+			s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))
 			headReorgEpoch := phase0.Epoch(newReorg.Slot / spec.SlotsPerEpoch)
 			baseReorgEpoch := phase0.Epoch((newReorg.Slot - phase0.Slot(newReorg.Depth)) / spec.SlotsPerEpoch)
 

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -43,10 +43,15 @@ var (
 		DO NOTHING;
 	`
 	SelectLastSlot = `
-	SELECT f_slot
-	FROM t_block_metrics
-	ORDER BY f_slot DESC
-	LIMIT 1`
+		SELECT f_slot
+		FROM t_block_metrics
+		ORDER BY f_slot DESC
+		LIMIT 1`
+
+	DropBlocksQuery = `
+		DROP FROM t_block_metrics
+		WHERE f_slot >= $1;
+`
 )
 
 func insertBlock(inputBlock spec.AgnosticBlock) (string, []interface{}) {
@@ -95,4 +100,16 @@ func (p *PostgresDBService) ObtainLastSlot() (phase0.Slot, error) {
 	rows.Scan(&slot)
 	rows.Close()
 	return phase0.Slot(slot), nil
+}
+
+type BlockDropType phase0.Slot
+
+func (s BlockDropType) Type() spec.ModelType {
+	return spec.BlockDropModel
+}
+
+func DropBlocks(slot BlockDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropBlocksQuery, resultArgs
 }

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -49,7 +49,7 @@ var (
 		LIMIT 1`
 
 	DropBlocksQuery = `
-		DROP FROM t_block_metrics
+		DELETE FROM t_block_metrics
 		WHERE f_slot >= $1;
 `
 )

--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -47,6 +47,11 @@ var (
 		FROM t_epoch_metrics_summary
 		ORDER BY f_epoch DESC
 		LIMIT 1`
+
+	DropEpochsQuery = `
+	DELETE FROM t_epoch_metrics_summary
+	WHERE f_epoch >= $1;
+`
 )
 
 func insertEpoch(inputEpoch spec.Epoch) (string, []interface{}) {
@@ -85,4 +90,16 @@ func (p *PostgresDBService) ObtainLastEpoch() (phase0.Epoch, error) {
 	rows.Scan(&epoch)
 	rows.Close()
 	return phase0.Epoch(epoch), nil
+}
+
+type EpochDropType phase0.Epoch
+
+func (s EpochDropType) Type() spec.ModelType {
+	return spec.EpochDropModel
+}
+
+func DropEpochs(epoch EpochDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropEpochsQuery, resultArgs
 }

--- a/pkg/db/migrations/000013_create_reorg_table.down.sql
+++ b/pkg/db/migrations/000013_create_reorg_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_reorgs;

--- a/pkg/db/migrations/000013_create_reorg_table.up.sql
+++ b/pkg/db/migrations/000013_create_reorg_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS t_reorgs(
+	f_slot INT PRIMARY KEY,
+	f_depth INT,
+	f_old_head_block_root TEXT,
+	f_new_head_block_root TEXT,
+	f_old_head_state_root TEXT,
+	f_new_head_state_root TEXT);

--- a/pkg/db/proposer_duties.go
+++ b/pkg/db/proposer_duties.go
@@ -7,6 +7,7 @@ This file together with the model, has all the needed methods to interact with t
 */
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -21,6 +22,11 @@ var (
 		ON CONFLICT DO NOTHING;
 	`
 	// if there is a confilct the line already exists
+
+	DropProposerDutiesQuery = `
+	DELETE FROM t_proposer_duties
+	WHERE f_proposer_slot/32 >= $1;
+`
 )
 
 func insertProposerDuty(inputDuty spec.ProposerDuty) (string, []interface{}) {
@@ -37,4 +43,16 @@ func ProposerDutyOperation(inputDuty spec.ProposerDuty) (string, []interface{}) 
 	q, args := insertProposerDuty(inputDuty)
 	return q, args
 
+}
+
+type ProposerDutiesDropType phase0.Epoch
+
+func (s ProposerDutiesDropType) Type() spec.ModelType {
+	return spec.ProposerDutyDropModel
+}
+
+func DropProposerDuties(epoch ProposerDutiesDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropProposerDutiesQuery, resultArgs
 }

--- a/pkg/db/reorg.go
+++ b/pkg/db/reorg.go
@@ -32,10 +32,10 @@ func InsertReorg(inputReorg ReorgType) (string, []interface{}) {
 
 	resultArgs = append(resultArgs, inputReorg.Slot)
 	resultArgs = append(resultArgs, inputReorg.Depth)
-	resultArgs = append(resultArgs, inputReorg.OldHeadBlock)
-	resultArgs = append(resultArgs, inputReorg.NewHeadBlock)
-	resultArgs = append(resultArgs, inputReorg.OldHeadState)
-	resultArgs = append(resultArgs, inputReorg.NewHeadState)
+	resultArgs = append(resultArgs, inputReorg.OldHeadBlock.String())
+	resultArgs = append(resultArgs, inputReorg.NewHeadBlock.String())
+	resultArgs = append(resultArgs, inputReorg.OldHeadState.String())
+	resultArgs = append(resultArgs, inputReorg.NewHeadState.String())
 
 	return InsertReorgQuery, resultArgs
 }

--- a/pkg/db/reorg.go
+++ b/pkg/db/reorg.go
@@ -20,7 +20,7 @@ var (
 		f_old_head_block_root,
 		f_new_head_block_root,
 		f_old_head_state_root,
-		f_new_head_state_root
+		f_new_head_state_root)
 		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT ON CONSTRAINT t_reorgs_pkey
 		DO NOTHING;

--- a/pkg/db/reorg.go
+++ b/pkg/db/reorg.go
@@ -1,0 +1,58 @@
+package db
+
+/*
+
+This file together with the model, has all the needed methods to interact with the epoch_metrics table of the database
+
+*/
+
+import (
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+// Postgres intregration variables
+var (
+	InsertReorgQuery = `
+	INSERT INTO t_reorgs (
+		f_slot,
+		f_depth,
+		f_old_head_block_root,
+		f_new_head_block_root,
+		f_old_head_state_root,
+		f_new_head_state_root
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT ON CONSTRAINT t_reorgs_pkey
+		DO NOTHING;
+	`
+)
+
+func InsertReorg(inputReorg ReorgType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+
+	resultArgs = append(resultArgs, inputReorg.Slot)
+	resultArgs = append(resultArgs, inputReorg.Depth)
+	resultArgs = append(resultArgs, inputReorg.OldHeadBlock)
+	resultArgs = append(resultArgs, inputReorg.NewHeadBlock)
+	resultArgs = append(resultArgs, inputReorg.OldHeadState)
+	resultArgs = append(resultArgs, inputReorg.NewHeadState)
+
+	return InsertReorgQuery, resultArgs
+}
+
+type ReorgType api.ChainReorgEvent
+
+func (s ReorgType) Type() spec.ModelType {
+	return spec.ReorgModel
+}
+
+func ReorgTypeFromReorg(input api.ChainReorgEvent) ReorgType {
+	return ReorgType{
+		Slot:         input.Slot,
+		Depth:        input.Depth,
+		OldHeadBlock: input.OldHeadBlock,
+		NewHeadBlock: input.NewHeadBlock,
+		OldHeadState: input.OldHeadState,
+		NewHeadState: input.NewHeadState,
+	}
+}

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -132,6 +132,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := BlockOperation(task.(spec.AgnosticBlock))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.BlockDropModel:
+						q, args := DropBlocks(task.(BlockDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.EpochModel:
 						q, args := EpochOperation(task.(spec.Epoch))
 						persis.query = q
@@ -156,8 +160,16 @@ func (p *PostgresDBService) runWriters() {
 						q, args := WithdrawalOperation(task.(spec.Withdrawal))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.WithdrawalDropModel:
+						q, args := DropWitdrawals(task.(WithdrawalDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.TransactionsModel:
 						q, args := TransactionOperation(task.(*spec.AgnosticTransaction))
+						persis.query = q
+						persis.values = append(persis.values, args...)
+					case spec.TransactionDropModel:
+						q, args := DropTransactions(task.(TransactionDropType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
 					default:

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -184,6 +184,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := DropTransactions(task.(TransactionDropType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.ReorgModel:
+						q, args := InsertReorg(task.(ReorgType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					default:
 						err = fmt.Errorf("could not figure out the type of write task")
 						wlog.Errorf("could not process incoming task, %s", err)

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -140,6 +140,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := EpochOperation(task.(spec.Epoch))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.EpochDropModel:
+						q, args := DropEpochs(task.(EpochDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.PoolSummaryModel:
 						q, args := PoolOperation(task.(spec.PoolSummary))
 						persis.query = q
@@ -148,12 +152,20 @@ func (p *PostgresDBService) runWriters() {
 						q, args := ProposerDutyOperation(task.(spec.ProposerDuty))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.ProposerDutyDropModel:
+						q, args := DropProposerDuties(task.(ProposerDutiesDropType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					case spec.ValidatorLastStatusModel:
 						q, args := ValidatorLastStatusOperation(task.(spec.ValidatorLastStatus))
 						persis.query = q
 						persis.values = append(persis.values, args...)
 					case spec.ValidatorRewardsModel:
 						q, args := ValidatorOperation(task.(spec.ValidatorRewards))
+						persis.query = q
+						persis.values = append(persis.values, args...)
+					case spec.ValidatorRewardDropModel:
+						q, args := DropValidatorRewards(task.(ValidatorRewardsDropType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
 					case spec.WithdrawalModel:

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -1,16 +1,22 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
 var (
 	UpsertTransaction = `
-INSERT INTO t_transactions(
-	f_tx_type, f_chain_id, f_data, f_gas, f_gas_price, f_gas_tip_cap, f_gas_fee_cap, f_value, f_nonce, f_to, f_hash,
-                           f_size, f_slot, f_el_block_number, f_timestamp, f_from, f_contract_address)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-ON CONFLICT DO NOTHING;`
+		INSERT INTO t_transactions(
+			f_tx_type, f_chain_id, f_data, f_gas, f_gas_price, f_gas_tip_cap, f_gas_fee_cap, f_value, f_nonce, f_to, f_hash,
+								f_size, f_slot, f_el_block_number, f_timestamp, f_from, f_contract_address)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		ON CONFLICT DO NOTHING;`
+
+	DropTransactionsQuery = `
+		DROP FROM t_transactions
+		WHERE f_slot >= $1;
+`
 )
 
 /**
@@ -50,4 +56,16 @@ func TransactionOperation(transaction *spec.AgnosticTransaction) (string, []inte
 	q, args := insertTransaction(transaction)
 
 	return q, args
+}
+
+type TransactionDropType phase0.Slot
+
+func (s TransactionDropType) Type() spec.ModelType {
+	return spec.TransactionDropModel
+}
+
+func DropTransactions(slot TransactionDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropTransactionsQuery, resultArgs
 }

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -14,7 +14,7 @@ var (
 		ON CONFLICT DO NOTHING;`
 
 	DropTransactionsQuery = `
-		DROP FROM t_transactions
+		DELETE FROM t_transactions
 		WHERE f_slot >= $1;
 `
 )

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -39,9 +40,9 @@ var (
 				f_status = excluded.f_status;
 	`
 
-	Drop = `
+	DropValidatorRewardsQuery = `
 		DROP FROM t_validator_rewards_summary
-		WHERE f_val_idx = $1 AND f_epoch = $2;
+		WHERE f_epoch >= $1;
 	`
 )
 
@@ -68,4 +69,16 @@ func ValidatorOperation(inputValidator spec.ValidatorRewards) (string, []interfa
 
 	q, args := insertValidator(inputValidator)
 	return q, args
+}
+
+type ValidatorRewardsDropType phase0.Epoch
+
+func (s ValidatorRewardsDropType) Type() spec.ModelType {
+	return spec.ValidatorRewardDropModel
+}
+
+func DropValidatorRewards(epoch ValidatorRewardsDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, epoch)
+	return DropValidatorRewardsQuery, resultArgs
 }

--- a/pkg/db/withdrawals.go
+++ b/pkg/db/withdrawals.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
@@ -21,6 +22,11 @@ var (
 			f_address = excluded.f_address,
 			f_amount = excluded.f_amount;
 	`
+
+	DropWithdrawalsQuery = `
+		DROP FROM t_withdrawals
+		WHERE f_slot >= $1;
+`
 )
 
 func insertWithdrawal(inputWithdrawal spec.Withdrawal) (string, []interface{}) {
@@ -38,4 +44,16 @@ func WithdrawalOperation(inputWithdrawal spec.Withdrawal) (string, []interface{}
 
 	q, args := insertWithdrawal(inputWithdrawal)
 	return q, args
+}
+
+type WithdrawalDropType phase0.Slot
+
+func (s WithdrawalDropType) Type() spec.ModelType {
+	return spec.WithdrawalDropModel
+}
+
+func DropWitdrawals(slot WithdrawalDropType) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, slot)
+	return DropWithdrawalsQuery, resultArgs
 }

--- a/pkg/db/withdrawals.go
+++ b/pkg/db/withdrawals.go
@@ -24,7 +24,7 @@ var (
 	`
 
 	DropWithdrawalsQuery = `
-		DROP FROM t_withdrawals
+		DELETE FROM t_withdrawals
 		WHERE f_slot >= $1;
 `
 )

--- a/pkg/events/finalized_checkpoint.go
+++ b/pkg/events/finalized_checkpoint.go
@@ -4,9 +4,9 @@ import api "github.com/attestantio/go-eth2-client/api/v1"
 
 func (e *Events) SubscribeToFinalizedCheckpointEvents() {
 	// subscribe to head event
-	err := e.cli.Api.Events(e.ctx, []string{"finalized_checkpoint"}, e.HandleCheckpointEvent) // every new head
+	err := e.cli.Api.Events(e.ctx, []string{"finalized_checkpoint"}, e.HandleCheckpointEvent) // every new checkpoint
 	if err != nil {
-		log.Panicf("failed to subscribe to head events: %s", err)
+		log.Panicf("failed to subscribe to finalized checkpoint events: %s", err)
 	}
 	log.Infof("subscribed to finalized checkpoint events")
 }

--- a/pkg/events/reorg.go
+++ b/pkg/events/reorg.go
@@ -20,8 +20,5 @@ func (e *Events) HandleReorgEvent(event *api.Event) {
 	data := event.Data.(*api.ChainReorgEvent) // cast to head event
 	log.Infof("Received a new event: slot %d of depth %d", data.Slot, data.Depth)
 
-	select { // only notify if we can
-	case e.ReorgChan <- *data:
-	default:
-	}
+	e.ReorgChan <- *data
 }

--- a/pkg/events/reorg.go
+++ b/pkg/events/reorg.go
@@ -1,0 +1,27 @@
+package events
+
+import api "github.com/attestantio/go-eth2-client/api/v1"
+
+func (e *Events) SubscribeToReorgsEvents() {
+	// subscribe to head event
+	err := e.cli.Api.Events(e.ctx, []string{"chain_reorg"}, e.HandleReorgEvent) // every reorg
+	if err != nil {
+		log.Panicf("failed to subscribe to chain_reorg events: %s", err)
+	}
+	log.Infof("subscribed to chain_reorg events")
+}
+
+func (e *Events) HandleReorgEvent(event *api.Event) {
+	log := log.WithField("routine", "reorg-event")
+	if event.Data == nil {
+		return
+	}
+
+	data := event.Data.(*api.ChainReorgEvent) // cast to head event
+	log.Infof("Received a new event: slot %d of depth %d", data.Slot, data.Depth)
+
+	select { // only notify if we can
+	case e.ReorgChan <- *data:
+	default:
+	}
+}

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -23,6 +23,7 @@ type Events struct {
 
 	SubscribedFinalized bool
 	FinalizedChan       chan api.FinalizedCheckpointEvent
+	ReorgChan           chan api.ChainReorgEvent
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
@@ -33,5 +34,6 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		HeadChan:            make(chan phase0.Slot),
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
+		ReorgChan:           make(chan api.ChainReorgEvent),
 	}
 }

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -41,10 +41,13 @@ const (
 	BlockModel ModelType = iota
 	BlockDropModel
 	EpochModel
+	EpochDropModel
 	PoolSummaryModel
 	ProposerDutyModel
+	ProposerDutyDropModel
 	ValidatorLastStatusModel
 	ValidatorRewardsModel
+	ValidatorRewardDropModel
 	WithdrawalModel
 	WithdrawalDropModel
 	TransactionsModel

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -52,6 +52,7 @@ const (
 	WithdrawalDropModel
 	TransactionsModel
 	TransactionDropModel
+	ReorgModel
 )
 
 type ValidatorStatus int8

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -39,13 +39,16 @@ type ModelType int8
 
 const (
 	BlockModel ModelType = iota
+	BlockDropModel
 	EpochModel
 	PoolSummaryModel
 	ProposerDutyModel
 	ValidatorLastStatusModel
 	ValidatorRewardsModel
 	WithdrawalModel
+	WithdrawalDropModel
 	TransactionsModel
+	TransactionDropModel
 )
 
 type ValidatorStatus int8


### PR DESCRIPTION
# Motivation
After being able to track finalized states we have realized it would be easier to simply track reorg events and then redownload the blocks and states.

# Description
With this Pull Request we intend to track reorg events, redownload the blocks and states and rewrite the metrics. By tracking reorgs and not the finalized we keep orphaned blocks, as we do not go back to the finalized. In the case of the states, we always go back to the finalized checkpoint, as there are no orphaned states.

# TODOs
- Track reorg events
- Delete and redownload block and state in case of reorg
- Store reorg event in a separate table