### PR TITLE
Feature/store genesis time

### DIFF
--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -87,6 +87,8 @@ func NewBlockAnalyzer(
 		PromMetrics:         promethMetrics,
 	}
 
+	InitGenesis(analyzer.dbClient, analyzer.cli)
+
 	analyzerMet := analyzer.GetMetrics()
 	promethMetrics.AddMeticsModule(analyzerMet)
 

--- a/pkg/analyzer/state.go
+++ b/pkg/analyzer/state.go
@@ -132,6 +132,8 @@ func NewStateAnalyzer(
 		PromMetrics:        promethMetrics,
 	}
 
+	InitGenesis(analyzer.dbClient, analyzer.cli)
+
 	analyzerMet := analyzer.GetMetrics()
 	promethMetrics.AddMeticsModule(analyzerMet)
 

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/db"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/sirupsen/logrus"
 )
@@ -150,4 +152,19 @@ func (s *SlotRootHistory) CheckFinalized(iSlot phase0.Slot, iRoot phase0.Root) (
 		}
 	}
 	return true, iSlot // slot is not in the history
+}
+
+func InitGenesis(dbClient *db.PostgresDBService, apiClient *clientapi.APIClient) {
+	// Get genesis from the API
+	apiGenesis := apiClient.RequestGenesis()
+
+	// Insert into db, this does nothing if there was a genesis before
+	dbClient.InsertGenesis(apiGenesis.Unix())
+
+	dbGenesis := dbClient.ObtainGenesis()
+
+	if apiGenesis.Unix() != dbGenesis {
+		log.Panicf("the genesis time in the database does not match the API, is the beacon node in the correct network?")
+	}
+
 }

--- a/pkg/clientapi/genesis.go
+++ b/pkg/clientapi/genesis.go
@@ -1,0 +1,12 @@
+package clientapi
+
+import "time"
+
+func (s APIClient) RequestGenesis() time.Time {
+	genesis, err := s.Api.GenesisTime(s.ctx)
+	if err != nil {
+		log.Panicf("could not get genesis time: %s", err)
+	}
+
+	return genesis
+}

--- a/pkg/db/genesis.go
+++ b/pkg/db/genesis.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"log"
+)
+
+/*
+
+This file together with the model, has all the needed methods to interact with the epoch_metrics table of the database
+
+*/
+
+// Postgres intregration variables
+var (
+	InsertGenesisQuery = `
+	INSERT INTO t_genesis (
+		f_genesis_time)
+		VALUES ($1)
+		ON CONFLICT ON CONSTRAINT t_genesis_pkey
+		DO NOTHING;
+	`
+
+	GetGenesisQuery = `
+	SELECT f_genesis_time
+	FROM t_genesis;
+`
+)
+
+// in case the table did not exist
+func (p *PostgresDBService) ObtainGenesis() int64 {
+	// create the tables
+	rows, err := p.psqlPool.Query(p.ctx, GetGenesisQuery)
+	if err != nil {
+		rows.Close()
+		log.Panicf("error obtaining genesis from database: %s", err)
+	}
+	genesis := int64(0)
+	rows.Next()
+	rows.Scan(&genesis)
+	rows.Close()
+	return genesis
+}
+
+// in case the table did not exist
+func (p *PostgresDBService) InsertGenesis(genesisTime int64) {
+	// create the tables
+	rows, err := p.psqlPool.Query(p.ctx, InsertGenesisQuery, genesisTime)
+	if err != nil {
+		rows.Close()
+		log.Panicf("error inserting genesis into database: %s", err)
+	}
+	rows.Close()
+}

--- a/pkg/db/migrations/000015_create_genesis_table.down.sql
+++ b/pkg/db/migrations/000015_create_genesis_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_genesis;

--- a/pkg/db/migrations/000015_create_genesis_table.up.sql
+++ b/pkg/db/migrations/000015_create_genesis_table.up.sql
@@ -1,0 +1,2 @@
+CREATE TABLE IF NOT EXISTS t_genesis(
+	f_genesis_time BIGINT PRIMARY KEY);


### PR DESCRIPTION
# Motivation
Right now it does not matter which beacon node the tool connects to. It simply processes slots or follows the head blocks and states. Therefore, it could happen that we accidentally connect the tool to a beacon node in a different network and we would not notice.

# Description
With this feature, we intend to make sure that the tool checks the genesis time and verifies the beacon node is in the same network as the data already persisted in the database.
We will download the genesis from the beacon node, query the database and compare both values. If they do not match, panic.

# TODOs

- [x] Query the Beacon Node for the Genesis
- [x] Add database select and insert to handle genesis time (on insert do nothing, never overwrite)
- [x] Retrieve both on startup and panic when different 

# Logs
```
time="2023-07-10T13:20:55+02:00" level=info msg="Launching Beacon State Writers" module=postgres-db
time="2023-07-10T13:20:55+02:00" level=info msg="Launching 10 Beacon State Writers" module=postgres-db
time="2023-07-10T13:20:55+02:00" level=panic msg="the genesis time in the database does not match the API, is the beacon node in the correct network?" module=analyzer
```