### PR TITLE
Add more validator data

### DIFF
--- a/pkg/analyzer/validator.go
+++ b/pkg/analyzer/validator.go
@@ -64,17 +64,6 @@ loop:
 					s.dbClient.Persist(maxRewards)
 				}
 
-				if s.metrics.PoolSummary && valTask.PoolName != "" {
-					summaryMet.AddValidator(maxRewards)
-				}
-
-			}
-
-			if s.metrics.PoolSummary && summaryMet.PoolName != "" {
-				// only send summary batch in case pools were introduced by the user and we have a name to identify it
-
-				wlog.Debugf("Sending pool summary batch (%s) to be stored...", summaryMet.PoolName)
-				s.dbClient.Persist(summaryMet)
 			}
 			wlog.Debugf("Validator group processed, worker freed for next group. Took %f seconds", time.Since(snapshot).Seconds())
 

--- a/pkg/analyzer/validator.go
+++ b/pkg/analyzer/validator.go
@@ -47,11 +47,17 @@ loop:
 				if valTask.Finalized {
 					// Only update validator last status on Finalized
 					// We will always receive higher epochs
+					validator := valTask.StateMetricsObj.GetMetricsBase().CurrentState.Validators[valIdx]
 					s.dbClient.Persist(spec.ValidatorLastStatus{
-						ValIdx:         phase0.ValidatorIndex(valIdx),
-						Epoch:          valTask.StateMetricsObj.GetMetricsBase().CurrentState.Epoch,
-						CurrentBalance: valTask.StateMetricsObj.GetMetricsBase().NextState.Balances[valIdx],
-						CurrentStatus:  maxRewards.Status,
+						ValIdx:          phase0.ValidatorIndex(valIdx),
+						Epoch:           valTask.StateMetricsObj.GetMetricsBase().CurrentState.Epoch,
+						CurrentBalance:  valTask.StateMetricsObj.GetMetricsBase().CurrentState.Balances[valIdx],
+						CurrentStatus:   maxRewards.Status,
+						Slashed:         validator.Slashed,
+						ActivationEpoch: validator.ActivationEpoch,
+						WithdrawalEpoch: validator.WithdrawableEpoch,
+						ExitEpoch:       validator.ExitEpoch,
+						PublicKey:       validator.PublicKey,
 					})
 				}
 				if s.metrics.ValidatorRewards { // only if flag is activated

--- a/pkg/analyzer/validator.go
+++ b/pkg/analyzer/validator.go
@@ -24,12 +24,6 @@ loop:
 			// Proccess State
 			snapshot := time.Now()
 
-			// batch metrics
-			summaryMet := spec.PoolSummary{
-				PoolName: valTask.PoolName,
-				Epoch:    valTask.StateMetricsObj.GetMetricsBase().NextState.Epoch,
-			}
-
 			// process each validator
 			for _, valIdx := range valTask.ValIdxs {
 

--- a/pkg/db/migrations/000021_add_validator_status_columns.down.sql
+++ b/pkg/db/migrations/000021_add_validator_status_columns.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE t_validator_last_status
+DROP COLUMN IF EXISTS f_slashed,
+DROP COLUMN IF EXISTS f_activation_epoch,
+DROP COLUMN IF EXISTS f_withdrawal_epoch,
+DROP COLUMN IF EXISTS f_exit_epoch,
+DROP COLUMN IF EXISTS f_public_key;

--- a/pkg/db/migrations/000021_add_validator_status_columns.up.sql
+++ b/pkg/db/migrations/000021_add_validator_status_columns.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE t_validator_last_status
+ADD COLUMN f_slashed bool,
+ADD COLUMN f_activation_epoch int,
+ADD COLUMN f_withdrawal_epoch numeric,
+ADD COLUMN f_exit_epoch numeric,
+ADD COLUMN f_public_key text;

--- a/pkg/db/validator_last_status.go
+++ b/pkg/db/validator_last_status.go
@@ -11,14 +11,24 @@ var (
 		f_val_idx, 
 		f_epoch, 
 		f_balance_eth, 
-		f_status)
-	VALUES ($1, $2, $3, $4)
+		f_status,
+		f_slashed,
+		f_activation_epoch,
+		f_withdrawal_epoch,
+		f_exit_epoch,
+		f_public_key)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	ON CONFLICT ON CONSTRAINT t_validator_last_status_pkey
 		DO 
 			UPDATE SET 
 				f_epoch = excluded.f_epoch, 
 				f_balance_eth = excluded.f_balance_eth,
-				f_status = excluded.f_status;
+				f_status = excluded.f_status,
+				f_slashed = excluded.f_slashed,
+				f_activation_epoch = excluded.f_activation_epoch,
+				f_withdrawal_epoch = excluded.f_withdrawal_epoch,
+				f_exit_epoch = excluded.f_exit_epoch,
+				f_public_key = excluded.f_public_key;
 	`
 )
 
@@ -28,6 +38,11 @@ func insertValidatorLastStatus(inputValidator spec.ValidatorLastStatus) (string,
 	resultArgs = append(resultArgs, inputValidator.Epoch)
 	resultArgs = append(resultArgs, inputValidator.BalanceToEth())
 	resultArgs = append(resultArgs, inputValidator.CurrentStatus)
+	resultArgs = append(resultArgs, inputValidator.Slashed)
+	resultArgs = append(resultArgs, inputValidator.ActivationEpoch)
+	resultArgs = append(resultArgs, inputValidator.WithdrawalEpoch)
+	resultArgs = append(resultArgs, inputValidator.ExitEpoch)
+	resultArgs = append(resultArgs, inputValidator.PublicKey.String())
 
 	return UpsertValidatorLastStatus, resultArgs
 }

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -7,7 +7,7 @@ import (
 
 // Postgres intregration variables
 var (
-	UpsertValidator = `
+	InsertValidator = `
 	INSERT INTO t_validator_rewards_summary (	
 		f_val_idx, 
 		f_epoch, 
@@ -50,7 +50,7 @@ func insertValidator(inputValidator spec.ValidatorRewards) (string, []interface{
 	resultArgs = append(resultArgs, inputValidator.MissingTarget)
 	resultArgs = append(resultArgs, inputValidator.MissingHead)
 	resultArgs = append(resultArgs, inputValidator.Status)
-	return UpsertValidator, resultArgs
+	return InsertValidator, resultArgs
 }
 
 func ValidatorOperation(inputValidator spec.ValidatorRewards) (string, []interface{}) {

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -25,19 +25,7 @@ var (
 		f_status)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	ON CONFLICT ON CONSTRAINT t_validator_rewards_summary_pkey
-		DO 
-			UPDATE SET 
-				f_epoch = excluded.f_epoch, 
-				f_balance_eth = excluded.f_balance_eth,
-				f_reward = excluded.f_reward,
-				f_max_reward = excluded.f_max_reward,
-				f_att_slot = excluded.f_att_slot,
-				f_base_reward = excluded.f_base_reward,
-				f_in_sync_committee = excluded.f_in_sync_committee,
-				f_missing_source = excluded.f_missing_source,
-				f_missing_target = excluded.f_missing_target,
-				f_missing_head = excluded.f_missing_head,
-				f_status = excluded.f_status;
+		DO NOTHING;
 	`
 
 	DropValidatorRewardsQuery = `

--- a/pkg/spec/validator_last_status.go
+++ b/pkg/spec/validator_last_status.go
@@ -5,10 +5,15 @@ import (
 )
 
 type ValidatorLastStatus struct {
-	ValIdx         phase0.ValidatorIndex
-	Epoch          phase0.Epoch
-	CurrentBalance phase0.Gwei
-	CurrentStatus  ValidatorStatus
+	ValIdx          phase0.ValidatorIndex
+	Epoch           phase0.Epoch
+	CurrentBalance  phase0.Gwei
+	CurrentStatus   ValidatorStatus
+	Slashed         bool
+	ActivationEpoch phase0.Epoch
+	WithdrawalEpoch phase0.Epoch
+	ExitEpoch       phase0.Epoch
+	PublicKey       phase0.BLSPubKey
 }
 
 func (f ValidatorLastStatus) Type() ModelType {


### PR DESCRIPTION
# Motivation
We have been requested to extract the activation epoch of the validators, in order to calculate the lifetime of each of the validators in the beacon chain.

# Description
As we will be adding a new field to the `t_validator_last_status` table, we will also add some extra fields:
- Activation Epoch
- Exit Epoch
- Slashed (whether it has ever been slashed)
- Withdrawable epoch
- Public Key

# TODOs
- [x] Add new fields in the spec structure
- [x] Add new fields to the query and db methods
- [x] Add columns to the table through the migrations
- [x]  Collect the new fields from the State and persist them 

![image](https://github.com/cortze/goteth/assets/18716811/1cd5744e-307b-4708-814c-2ed68c232a18)
