### PR TITLE
Fix rewind on reorg crossing epoch boundaries

### DIFF
--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -123,6 +123,7 @@ func (s *ChainAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 
 			nextSlotDownload = newReorg.Slot - phase0.Slot(newReorg.Depth) + 1
 			s.ReorgRewind(nextSlotDownload)
+			queue.ReOrganizeReorg(phase0.Epoch(nextSlotDownload / spec.SlotsPerEpoch))
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing block requester routine")

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -185,11 +185,11 @@ func (s *ChainAnalyzer) ReorgRewind(baseSlot phase0.Slot, slot phase0.Slot) {
 	reorgEpoch := phase0.Epoch(slot / spec.SlotsPerEpoch)
 	if slot%spec.SlotsPerEpoch == 31 || // end of epoch
 		baseEpoch != reorgEpoch { // the reorg crosses and epoch boundary
-		epoch := slot / spec.SlotsPerEpoch
+		epoch := baseEpoch - 1
 		log.Infof("deleting epoch data from %d (included) onwards", epoch)
 		s.dbClient.Persist(db.EpochDropType(epoch))
 		s.dbClient.Persist(db.ProposerDutiesDropType(epoch))
-		s.dbClient.Persist(db.ValidatorRewardsDropType(epoch))
+		s.dbClient.Persist(db.ValidatorRewardsDropType(epoch + 1)) // validator rewards are always written at epoch+1
 	}
 
 }

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -81,6 +81,19 @@ func (s *StateQueue) AddRoot(iSlot phase0.Slot, iRoot phase0.Root) {
 	})
 }
 
+func (s *StateQueue) ReOrganizeReorg(baseEpoch phase0.Epoch) {
+
+	for s.currentState.Epoch >= baseEpoch {
+		// we need to rewrite metrics
+		// rewrite epoch metrics which are the earliest written (at the currentstate)
+		// validator metrics are written at nextstate, so they will be written anyways
+
+		s.nextState = s.currentState
+		s.currentState = s.prevState
+		s.prevState = spec.AgnosticState{} // epoch = 0, the loop will stop after three loops
+	}
+}
+
 func (s *StateQueue) CheckFinalized(iSlot phase0.Slot, iRoot phase0.Root) (phase0.Epoch, bool) {
 
 	if s.LatestFinalized.Epoch == 0 {

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -83,7 +83,7 @@ func (s *StateQueue) AddRoot(iSlot phase0.Slot, iRoot phase0.Root) {
 
 func (s *StateQueue) ReOrganizeReorg(baseEpoch phase0.Epoch) {
 
-	for s.currentState.Epoch >= baseEpoch {
+	for s.nextState.Epoch >= baseEpoch {
 		// we need to rewrite metrics
 		// rewrite epoch metrics which are the earliest written (at the currentstate)
 		// validator metrics are written at nextstate, so they will be written anyways

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-"context"
+	"context"
 	"time"
 
 	pgx "github.com/jackc/pgx/v4"
@@ -14,25 +14,25 @@ var (
 	QueryTimeout = 5 * time.Minute
 	MaxRetries   = 1
 
-	ErrorNoConnFree = "no connection adquirable"
-	noQueryError  string = "no error"
-	noQueryResult string = "no result"
+	ErrorNoConnFree        = "no connection adquirable"
+	noQueryError    string = "no error"
+	noQueryResult   string = "no result"
 )
 
 type QueryBatch struct {
-	ctx     context.Context
-	pgxPool *pgxpool.Pool
-	batch   *pgx.Batch
-	size    int
+	ctx          context.Context
+	pgxPool      *pgxpool.Pool
+	batch        *pgx.Batch
+	size         int
 	persistables []Persistable
 }
 
 func NewQueryBatch(ctx context.Context, pgxPool *pgxpool.Pool, batchSize int) *QueryBatch {
 	return &QueryBatch{
-		ctx:     ctx,
-		pgxPool: pgxPool,
-		batch:   &pgx.Batch{},
-		size:    batchSize,
+		ctx:          ctx,
+		pgxPool:      pgxPool,
+		batch:        &pgx.Batch{},
+		size:         batchSize,
 		persistables: make([]Persistable, 0),
 	}
 }
@@ -101,8 +101,8 @@ func (q *QueryBatch) persistBatch() error {
 	// check if there was any error
 	if qerr != nil {
 		log.WithFields(log.Fields{
-			"error": qerr.Error(),
-			"query": q.persistables[cnt-1].query,
+			"error":  qerr.Error(),
+			"query":  q.persistables[cnt-1].query,
 			"values": q.persistables[cnt-1].values,
 		}).Errorf("unable to persist query [%d]", cnt-1)
 		return errors.Wrap(qerr, "error persisting batch")
@@ -115,12 +115,11 @@ func (q *QueryBatch) cleanBatch() {
 	q.persistables = make([]Persistable, 0)
 }
 
-
 // persistable is the main structure fed to the batcher
-// allows to link batching errors with the query and values 
+// allows to link batching errors with the query and values
 // that generated it
 type Persistable struct {
-	query string
+	query  string
 	values []interface{}
 }
 
@@ -133,4 +132,3 @@ func NewPersistable() Persistable {
 func (p *Persistable) isEmpty() bool {
 	return p.query == ""
 }
-

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -29,7 +29,7 @@ var (
 	`
 
 	DropValidatorRewardsQuery = `
-		DROP FROM t_validator_rewards_summary
+		DELETE FROM t_validator_rewards_summary
 		WHERE f_epoch >= $1;
 	`
 )


### PR DESCRIPTION
# Description
We have recently deployed a pull request that rewinds metrics back when there is a reorg. However, epoch metrics depend on the state and they only need to be reminded when the state at the end slot of an epoch changes.
This pull request should fix the issue and only rewind epoch metrics when needed.
The use of Roots is not used for now, so they remain untouched until we start using them.

# TODOs
- [x] Calculate when the reorg crosses an epoch boundary
- [x] Rewind epoch metrics
- [x] Rewind validator metrics

  