### PR TITLE
Improve logs at finalized and fix slot rewind

### DIFF
--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -157,7 +157,6 @@ func (s ChainAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Sl
 	s.blockTaskChan <- blockTask
 
 	// store transactions if it has been enabled
-	startTime := time.Now()
 	if s.metrics.Transactions {
 		transactions, err := s.cli.RequestTransactionDetails(newBlock)
 		if err == nil {

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -175,10 +175,10 @@ func (s ChainAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Sl
 
 func (s *ChainAnalyzer) ReorgRewind(baseSlot phase0.Slot, slot phase0.Slot) {
 
-	log.Infof("deleting block data from %d (included) onwards", slot)
-	s.dbClient.Persist(db.BlockDropType(slot))
-	s.dbClient.Persist(db.TransactionDropType(slot))
-	s.dbClient.Persist(db.WithdrawalDropType(slot))
+	log.Infof("deleting block data from %d (included) onwards", baseSlot+1)
+	s.dbClient.Persist(db.BlockDropType(baseSlot + 1))
+	s.dbClient.Persist(db.TransactionDropType(baseSlot + 1))
+	s.dbClient.Persist(db.WithdrawalDropType(baseSlot + 1))
 
 	baseEpoch := phase0.Epoch(baseSlot / spec.SlotsPerEpoch)
 	reorgEpoch := phase0.Epoch(slot / spec.SlotsPerEpoch)

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -34,7 +34,7 @@ func (s *ChainAnalyzer) DownloadNewState(
 			Finalized: finalized,
 		}
 
-		log.Debugf("sending task for slot: %d", epochTask.State.Slot)
+		log.Tracef("sending task for slot: %d", epochTask.State.Slot)
 		s.epochTaskChan <- epochTask
 	}
 	// check if the min Request time has been completed (to avoid spaming the API)

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -25,7 +25,7 @@ loop:
 				log.Warn("the task channel has been closed, finishing block routine")
 				return
 			}
-			log.Infof("block task received for slot %d, analyzing...", task.Slot)
+			log.Tracef("block task received for slot %d, analyzing...", task.Slot)
 
 			s.dbClient.Persist(task.Block)
 

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -27,6 +27,7 @@ loop:
 			}
 			log.Tracef("block task received for slot %d, analyzing...", task.Slot)
 
+			log.Debugf("persisting block metrics: slot %d", task.Block.Slot)
 			s.dbClient.Persist(task.Block)
 
 			for _, item := range task.Block.ExecutionPayload.Withdrawals {

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -20,7 +20,7 @@ loop:
 
 		case task := <-s.epochTaskChan:
 
-			log.Infof("epoch task received for slot %d, epoch: %d, analyzing...", task.State.Slot, task.State.Epoch)
+			log.Tracef("epoch task received for slot %d, epoch: %d, analyzing...", task.State.Slot, task.State.Epoch)
 
 			// returns the state in a custom struct for Phase0, Altair of Bellatrix
 			stateMetrics, err := metrics.StateMetricsByForkVersion(task.NextState, task.State, task.PrevState, s.cli.Api)

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -65,6 +65,7 @@ loop:
 				// TODO: send constructor to model package
 				epochModel := stateMetrics.GetMetricsBase().ExportToEpoch()
 
+				log.Debugf("persisting epoch metrics: epoch %d", epochModel.Epoch)
 				s.dbClient.Persist(epochModel)
 
 				// Proposer Duties

--- a/pkg/analyzer/process_transactions.go
+++ b/pkg/analyzer/process_transactions.go
@@ -26,7 +26,7 @@ loop:
 				log.Warn("the transactions task channel has closed, finishing transaction routine")
 				return
 			}
-			log.Debugf("transaction task received for slot %d, analyzing...", task.Slot)
+			log.Tracef("transaction task received for slot %d, analyzing...", task.Slot)
 
 			for _, tx := range task.Transactions {
 				s.dbClient.Persist(tx)

--- a/pkg/analyzer/process_transactions.go
+++ b/pkg/analyzer/process_transactions.go
@@ -27,7 +27,7 @@ loop:
 				return
 			}
 			log.Tracef("transaction task received for slot %d, analyzing...", task.Slot)
-
+			log.Debugf("persisting transaction metrics: slot %d", task.Slot)
 			for _, tx := range task.Transactions {
 				s.dbClient.Persist(tx)
 			}

--- a/pkg/analyzer/validator.go
+++ b/pkg/analyzer/validator.go
@@ -20,7 +20,7 @@ loop:
 		select {
 		case valTask := <-s.valTaskChan:
 
-			wlog.Debugf("task received for val %d - %d in epoch %d", valTask.ValIdxs[0], valTask.ValIdxs[len(valTask.ValIdxs)-1], valTask.StateMetricsObj.GetMetricsBase().CurrentState.Epoch)
+			wlog.Tracef("task received for val %d - %d in epoch %d", valTask.ValIdxs[0], valTask.ValIdxs[len(valTask.ValIdxs)-1], valTask.StateMetricsObj.GetMetricsBase().CurrentState.Epoch)
 			// Proccess State
 			snapshot := time.Now()
 

--- a/pkg/analyzer/validator.go
+++ b/pkg/analyzer/validator.go
@@ -21,6 +21,9 @@ loop:
 		case valTask := <-s.valTaskChan:
 
 			wlog.Tracef("task received for val %d - %d in epoch %d", valTask.ValIdxs[0], valTask.ValIdxs[len(valTask.ValIdxs)-1], valTask.StateMetricsObj.GetMetricsBase().CurrentState.Epoch)
+			if s.metrics.ValidatorRewards { // only if flag is activated
+				wlog.Debugf("persising validator metrics: epoch %d", valTask.StateMetricsObj.GetMetricsBase().NextState.Epoch)
+			}
 			// Proccess State
 			snapshot := time.Now()
 

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	moduleName = "API-Cli"
+	moduleName = "api-cli"
 	log        = logrus.WithField(
-		"module", "")
+		"module", moduleName)
 	QueryTimeout = time.Second * 90
 )
 

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -2,6 +2,7 @@ package clientapi
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -14,7 +15,9 @@ import (
 )
 
 func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, bool, error) {
+	startTime := time.Now()
 	newBlock, err := s.Api.SignedBeaconBlock(s.ctx, fmt.Sprintf("%d", slot))
+	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 	if newBlock == nil {
 		log.Warnf("the beacon block at slot %d does not exist, missing block", slot)
 		return s.CreateMissingBlock(slot), false, nil
@@ -34,7 +37,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, boo
 	// fill in block size on custom block using RequestBlockByHash
 	block, err := s.RequestBlockByHash(common.Hash(customBlock.ExecutionPayload.BlockHash))
 	if err != nil {
-		log.Error(err)
+		log.Error("cannot request block by hash: %s", err)
 	}
 	if block != nil {
 		customBlock.Size = uint32(block.Size())

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -2,13 +2,16 @@ package clientapi
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	local_spec "github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 )
 
 func (s APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticState, error) {
+	startTime := time.Now()
 	newState, err := s.Api.BeaconState(s.ctx, fmt.Sprintf("%d", slot))
+	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 	if newState == nil {
 		return nil, fmt.Errorf("unable to retrieve Beacon State from the beacon node, closing requester routine. nil State")
 	}

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -54,7 +54,7 @@ func (q *QueryBatch) PersistBatch() error {
 	logEntry := log.WithFields(log.Fields{
 		"mod": "batch-persister",
 	})
-	wlog.Debugf("persisting batch of queries with len(%d)", q.Len())
+	wlog.Tracef("persisting batch of queries with len(%d)", q.Len())
 	var err error
 persistRetryLoop:
 	for i := 0; i < MaxRetries; i++ {

--- a/pkg/events/finalized_checkpoint.go
+++ b/pkg/events/finalized_checkpoint.go
@@ -18,7 +18,7 @@ func (e *Events) HandleCheckpointEvent(event *api.Event) {
 	}
 
 	data := event.Data.(*api.FinalizedCheckpointEvent) // cast to head event
-	log.Infof("Received a new event: epoch %d, state root: %s", data.Epoch, data.State.String())
+	log.Infof("New event: epoch %d, state root: %s", data.Epoch, data.State.String())
 
 	select { // only notify if we can
 	case e.FinalizedChan <- *data:

--- a/pkg/events/head.go
+++ b/pkg/events/head.go
@@ -24,8 +24,10 @@ func (e *Events) HandleHeadEvent(event *api.Event) {
 	data := event.Data.(*api.HeadEvent) // cast to head event
 	headEpoch := phase0.Epoch(data.Slot) / spec.SlotsPerEpoch
 
-	log.Infof("Received a new event: slot %d, epoch %d", data.Slot, data.Slot/spec.SlotsPerEpoch)
-	log.Infof("Pending slots for new epoch: %d", (int(headEpoch+1)*spec.EpochSlots)-int(data.Slot))
+	log.Infof("New event: slot %d, epoch %d. %d pending slots for new epoch",
+		data.Slot,
+		data.Slot/spec.SlotsPerEpoch,
+		(int(headEpoch+1)*spec.EpochSlots)-int(data.Slot))
 
 	select { // only notify if we can
 	case e.HeadChan <- data.Slot:

--- a/pkg/events/reorg.go
+++ b/pkg/events/reorg.go
@@ -18,7 +18,7 @@ func (e *Events) HandleReorgEvent(event *api.Event) {
 	}
 
 	data := event.Data.(*api.ChainReorgEvent) // cast to head event
-	log.Infof("Received a new event: slot %d of depth %d", data.Slot, data.Depth)
+	log.Infof("New event: slot %d of depth %d", data.Slot, data.Depth)
 
 	e.ReorgChan <- *data
 }

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -114,8 +114,8 @@ metricsUpdateLoop:
 
 func (p *PrometheusMetrics) Close() {
 	// Init loop for each of the Exporters
-	log.Debugf("closing %d prometheus metrics modules", len(p.Modules))
+	log.Infof("closing %d prometheus metrics modules", len(p.Modules))
 	p.closeC <- struct{}{}
 	p.wg.Wait()
-	log.Debug("prometheus metrics exporte successfully closed")
+	log.Infof("prometheus metrics exporte successfully closed")
 }


### PR DESCRIPTION
# Description
Right now there are many logs which are not used in the PROD scenario.
With this pull request we intend to send most of these logs to the debug and trace level, so when we run in PROD it is easy to understand and read the current state of the tool.

# TODOs
- Send all receive signals to trace
- Add download times for blocks and states
- Simplify the event logs

We also introduced a fix from a previous PR, when a reorg happens and some slot data needs to be deleted.
Instead of deleting at the reorg slot, we need to delete from the baseSlot+1 onwards.