### PR TITLE
Transaction Receipt: multi-thread requests

### DIFF
--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/config"
@@ -155,8 +156,10 @@ func (s *ChainAnalyzer) Run() {
 	wgProcess.Add(1)
 	go s.runProcessState(&wgProcess)
 
-	wgTransaction.Add(1)
-	go s.runProcessTransactions(&wgTransaction)
+	if s.metrics.Transactions {
+		wgTransaction.Add(1)
+		go s.runProcessTransactions(&wgTransaction)
+	}
 
 	for i := 0; i < s.validatorWorkerNum; i++ {
 		// state workers, receiving State and valIdx to measure performance

--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -98,7 +98,7 @@ func NewChainAnalyzer(
 		epochTaskChan:       make(chan *EpochTask, 1),
 		valTaskChan:         make(chan *ValTask, iConfig.WorkerNum),
 		blockTaskChan:       make(chan *BlockTask, 1),
-		transactionTaskChan: make(chan *TransactionTask, 1),
+		transactionTaskChan: make(chan *TransactionTask, iConfig.WorkerNum),
 		validatorWorkerNum:  iConfig.WorkerNum,
 		cli:                 cli,
 		dbClient:            idbClient,
@@ -206,8 +206,10 @@ type BlockTask struct {
 }
 
 type TransactionTask struct {
-	Slot         uint64
-	Transactions []*spec.AgnosticTransaction
+	Slot           phase0.Slot
+	BlockNumber    uint64
+	BlockTimestamp uint64
+	Transaction    bellatrix.Transaction
 }
 
 type EpochTask struct {

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -159,14 +159,13 @@ func (s ChainAnalyzer) DownloadNewBlock(history *SlotRootHistory, slot phase0.Sl
 
 	// store transactions if it has been enabled
 	if s.metrics.Transactions {
-		transactions, err := s.cli.RequestTransactionDetails(newBlock)
-		if err == nil {
-			transactionTask := &TransactionTask{
-				Slot:         uint64(slot),
-				Transactions: transactions,
-			}
+
+		for _, tx := range newBlock.ExecutionPayload.Transactions {
 			log.Tracef("sending a new tx task for slot %d", slot)
-			s.transactionTaskChan <- transactionTask
+			s.transactionTaskChan <- &TransactionTask{
+				Slot:        slot,
+				Transaction: tx,
+			}
 		}
 	}
 

--- a/pkg/analyzer/process_transactions.go
+++ b/pkg/analyzer/process_transactions.go
@@ -13,35 +13,50 @@ func (s *ChainAnalyzer) runProcessTransactions(wgProcess *sync.WaitGroup) {
 
 	log.Info("Launching Beacon Block Transactions Processor")
 	ticker := time.NewTicker(utils.RoutineFlushTimeout)
+	var wgTransactionWorkers sync.WaitGroup
 
-loop:
-	for {
-		// in case the downloads have finished, and there are no more tasks to execute
+	for i := 0; i < s.validatorWorkerNum; i++ {
 
-		select {
+		wgTransactionWorkers.Add(1)
 
-		case task, ok := <-s.transactionTaskChan:
+		go func() {
+			defer wgTransactionWorkers.Done()
+		loop:
+			for {
+				// in case the downloads have finished, and there are no more tasks to execute
 
-			if !ok {
-				log.Warn("the transactions task channel has closed, finishing transaction routine")
-				return
+				select {
+
+				case task, ok := <-s.transactionTaskChan:
+
+					if !ok {
+						log.Warn("the transactions task channel has closed, finishing transaction routine")
+						return
+					}
+					log.Tracef("transaction task received for slot %d, analyzing...", task.Slot)
+
+					detailedTx, err := s.cli.RequestTransactionDetails(task.Transaction, task.Slot, task.BlockNumber, task.BlockTimestamp)
+
+					if err != nil {
+						log.Errorf("could not request transaction details in slot %s", task.Slot, err)
+					}
+					log.Debugf("persisting transaction metrics: slot %d", task.Slot)
+					s.dbClient.Persist(detailedTx)
+
+				case <-ticker.C:
+					// in case the block processer has finished, and there are no more tasks to execute
+					if s.processerFinished && len(s.transactionTaskChan) == 0 {
+						log.Warn("the transactions task channel has been closed, finishing transaction routine")
+						break loop
+					}
+				case <-s.ctx.Done():
+					log.Info("context has died, closing block processer routine")
+					break loop
+				}
 			}
-			log.Tracef("transaction task received for slot %d, analyzing...", task.Slot)
-			log.Debugf("persisting transaction metrics: slot %d", task.Slot)
-			for _, tx := range task.Transactions {
-				s.dbClient.Persist(tx)
-			}
-		case <-ticker.C:
-			// in case the block processer has finished, and there are no more tasks to execute
-			if s.processerFinished && len(s.transactionTaskChan) == 0 {
-				log.Warn("the transactions task channel has been closed, finishing transaction routine")
-				break loop
-			}
-		case <-s.ctx.Done():
-			log.Info("context has died, closing block processer routine")
-			break loop
-		}
+		}()
 	}
 
+	wgTransactionWorkers.Wait()
 	log.Infof("Block transactions processor routine finished...")
 }

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -3,6 +3,7 @@ package clientapi
 import (
 	"encoding/hex"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,62 +17,61 @@ func (client APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
 }
 
 // convert transactions from byte sequences to Transaction object
-func (s APIClient) RequestTransactionDetails(block spec.AgnosticBlock) ([]*spec.AgnosticTransaction, error) {
-	processedTransactions := make([]*spec.AgnosticTransaction, 0)
+func (s APIClient) RequestTransactionDetails(iTx bellatrix.Transaction,
+	iSlot phase0.Slot,
+	iBlockNumber uint64,
+	iTimestamp uint64) (*spec.AgnosticTransaction, error) {
+	// starTime := time.Now()
 	if s.ELApi == nil {
 		log.Warn("EL endpoint not provided. The gas price read from the CL may not be the effective gas price.")
 	}
-	for idx := 0; idx < len(block.ExecutionPayload.Transactions); idx++ {
-		var parsedTx = &types.Transaction{}
-		if err := parsedTx.UnmarshalBinary(block.ExecutionPayload.Transactions[idx]); err != nil {
-			log.Warnf("unable to unmarshal transaction: %s", err)
-			return processedTransactions, err
-		}
-		from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), parsedTx)
+	var parsedTx = &types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(iTx); err != nil {
+		log.Warnf("unable to unmarshal transaction: %s", err)
+		return &spec.AgnosticTransaction{}, err
+	}
+	from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), parsedTx)
+	if err != nil {
+		log.Warnf("unable to retrieve sender address from transaction: %s", err)
+		return &spec.AgnosticTransaction{}, err
+	}
+
+	gasUsed := parsedTx.Gas()
+	gasPrice := parsedTx.GasPrice().Uint64()
+	contractAddress := *&common.Address{}
+
+	if s.ELApi != nil {
+		receipt, err := s.GetReceipt(parsedTx.Hash())
+
 		if err != nil {
-			log.Warnf("unable to retrieve sender address from transaction: %s", err)
-			return processedTransactions, err
+			log.Warnf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
+		} else {
+			gasUsed = receipt.GasUsed
+			gasPrice = receipt.EffectiveGasPrice.Uint64()
+			contractAddress = receipt.ContractAddress
 		}
-
-		gasUsed := parsedTx.Gas()
-		gasPrice := parsedTx.GasPrice().Uint64()
-		contractAddress := *&common.Address{}
-
-		if s.ELApi != nil {
-			receipt, err := s.GetReceipt(parsedTx.Hash())
-
-			if err != nil {
-				log.Warnf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
-			} else {
-				gasUsed = receipt.GasUsed
-				gasPrice = receipt.EffectiveGasPrice.Uint64()
-				contractAddress = receipt.ContractAddress
-			}
-
-		}
-
-		processedTransaction := &spec.AgnosticTransaction{
-			TxType:          parsedTx.Type(),
-			ChainId:         uint8(parsedTx.ChainId().Uint64()),
-			Data:            hex.EncodeToString(parsedTx.Data()),
-			Gas:             phase0.Gwei(gasUsed),
-			GasPrice:        phase0.Gwei(gasPrice),
-			GasTipCap:       phase0.Gwei(parsedTx.GasTipCap().Uint64()),
-			GasFeeCap:       phase0.Gwei(parsedTx.GasFeeCap().Uint64()),
-			Value:           phase0.Gwei(parsedTx.Value().Uint64()),
-			Nonce:           parsedTx.Nonce(),
-			To:              parsedTx.To(),
-			From:            from,
-			Hash:            phase0.Hash32(parsedTx.Hash()),
-			Size:            parsedTx.Size(),
-			Slot:            block.Slot,
-			BlockNumber:     block.ExecutionPayload.BlockNumber,
-			Timestamp:       block.ExecutionPayload.Timestamp,
-			ContractAddress: contractAddress,
-		}
-
-		processedTransactions = append(processedTransactions, processedTransaction)
 
 	}
-	return processedTransactions, nil
+
+	//log.Infof("transaction details took %f seconds", time.Since(starTime).Seconds())
+
+	return &spec.AgnosticTransaction{
+		TxType:          parsedTx.Type(),
+		ChainId:         uint8(parsedTx.ChainId().Uint64()),
+		Data:            hex.EncodeToString(parsedTx.Data()),
+		Gas:             phase0.Gwei(gasUsed),
+		GasPrice:        phase0.Gwei(gasPrice),
+		GasTipCap:       phase0.Gwei(parsedTx.GasTipCap().Uint64()),
+		GasFeeCap:       phase0.Gwei(parsedTx.GasFeeCap().Uint64()),
+		Value:           phase0.Gwei(parsedTx.Value().Uint64()),
+		Nonce:           parsedTx.Nonce(),
+		To:              parsedTx.To(),
+		From:            from,
+		Hash:            phase0.Hash32(parsedTx.Hash()),
+		Size:            parsedTx.Size(),
+		Slot:            iSlot,
+		BlockNumber:     iBlockNumber,
+		Timestamp:       iTimestamp,
+		ContractAddress: contractAddress,
+	}, nil
 }


### PR DESCRIPTION
# Motivation
To obtain the effective gas price of transactions it is needed to request the transaction receipts.
This feature is already implemented, but right now the receipts data is requested synchronously after the block.
The download times for 100 transactions are around 7 seconds, which is making the block download slower.

# Description
In order to solve the issue, we intend to run several goroutines that request the receipt data asynchronously. 
The block routine will launch the transaction in a channel and now we can request this data with several threads at the same time.

# TODOs
- [x] TransactionTask channel to receive a single transaction per task
- [x] Block download routine to send as many tasks as transactions
- [x] We will use the validator worker num as the number of goroutines to request receipts
- [x] Run go routine that listens to the channel, requests a receipt and persists to db   


# Logs
Logs in Goerli.
Right now block download takes around 1 second.
Look at the timestamp, the logged seconds are just for the block download, not the receipts.
But we cannot download the next block until receipts have been processed.

```
analyzer_1  | time="2023-07-19T14:38:49Z" level=info msg="summary for analyzer" last_processed_epoch=190803 last_processed_slot=6105782
analyzer_1  | time="2023-07-19T14:38:50Z" level=info msg="block at slot 6105784 downloaded in 0.102732 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:50Z" level=info msg="block at slot 6105785 downloaded in 0.124264 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:51Z" level=info msg="block at slot 6105786 downloaded in 0.201105 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:52Z" level=info msg="block at slot 6105787 downloaded in 0.107879 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:53Z" level=info msg="block at slot 6105788 downloaded in 0.108087 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:54Z" level=info msg="block at slot 6105789 downloaded in 0.071654 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:54Z" level=info msg="block at slot 6105790 downloaded in 0.157691 seconds" module=api-cli
analyzer_1  | time="2023-07-19T14:38:55Z" level=info msg="block at slot 6105791 downloaded in 0.028824 seconds" module=api-cli
```