### PR TITLE
add .github folder + pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Motivation
+<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
+
+_Related links:_
+ 
+# Description
+<!-- How are we approaching to solve the problem or deploy the new code -->
+<!-- What new structures will be added or what major changes will be applied -->
+
+# Tasks
+<!-- Checklist of tasks to do -->
+- [ ] 
+
+# Proof of Success 
+<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
+


### PR DESCRIPTION
# Motivation
Although we are making an effort to make the PRs more readable and appealing for the Reviewers, there is a lack of homogeneity across the PRs.

_Related links:_
 -- none --

# Description
This PR proposes this same exact template as the standard template for any other PR in the repo 

# Tasks
- [x] create the `.github` folder (usable for future GH.actions) and the `template.md`

# Proof of Success 
It needs to be part of the `master` branch to appear, but should be like this exact PR
